### PR TITLE
Update obsidian.css

### DIFF
--- a/obsidian.css
+++ b/obsidian.css
@@ -73,6 +73,7 @@
   --panel-border-color: #18191e;
   --search-text: #e0e0e0;
   --folder-title: #ffffff;
+  --mark-highlight: #e6c2755e;
 
   --gray-1: #5C6370;
   --gray-2: #abb2bf;
@@ -468,6 +469,12 @@ a.tag{
 /*code font size*/
 code{
   font-size: var(--font-size-code) !important;
+}
+
+
+/* mark highlighting */
+mark { 
+  background-color:  var(--mark-highlight)!important;
 }
 
 /* outliner for the outline */


### PR DESCRIPTION
Added a color and code to style markdown mark tags (ie persistent highlights). In markdown any text can be highlighted by encapsulating your text with ==

eg ==hightlight text==

Note this is in preview mode only. Haven't sorted out the editor mode yet so it's still the default orange