### PR TITLE
Change tab to 2 spaces, to fix YAML

### DIFF
--- a/obsidian.css
+++ b/obsidian.css
@@ -358,7 +358,7 @@ settings:
     title.zh: 使用半宽状态栏
     type: class-toggle
     default: false
-	-
+  -
     id: background-settings
     title: 2. Detail Settings
     title.zh: 2. 细节设置


### PR DESCRIPTION
The file looked valid, if IDE was set to 2 spaces-per-tab character. But it tripped up parsing of the theme settings with YAML readers.

This fixes #217