### PR TITLE
修复浅色模式下输入公式时字母不可见的问题

### DIFF
--- a/theme.css
+++ b/theme.css
@@ -12091,7 +12091,7 @@ body {
   --code-def: #82aaff;
   --code-property: #c792ea;
   --code-variable: #f07178;
-  --code-variable-2: #eeffff;
+  --code-variable-2: #53ada3;
   --code-variable-3: #e7852fe7;
   --code-definition: #82aaff;
   --code-callee: #89ddff;


### PR DESCRIPTION
--code-variable-2: #eeffff，这个颜色过淡，在深色模式下体验不错，但在浅色模式下完全不可见。我修改成了#53ada3，在浅色和深色模式下体验都不错。