### PR TITLE
移除 tasks-edit:after 中的 content

### DIFF
--- a/theme.css
+++ b/theme.css
@@ -25463,6 +25463,10 @@ a.tasks-edit {
   cursor: pointer;
 }
 
+a.tasks-edit:after {
+  content: none;
+}
+
 /* ================================== */
 /* ======= Hover editor======= */
 /* ================================== */


### PR DESCRIPTION
https://github.com/obsidian-tasks-group/obsidian-tasks 中添加了
```css
.tasks-edit:after {
  content: "\1f4dd";
}
```
导致任务后的编辑图标模糊 
![image](https://github.com/PKM-er/Blue-Topaz_Obsidian-css/assets/13983218/0d04ae1f-74de-4dad-bfc1-5b214c375f25)
