### PR TITLE
Feat/bases support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 
 Blue Topaz.css
 \[\!abstract\]-
+bookmarks.json
+*.py

--- a/obsidian.css
+++ b/obsidian.css
@@ -27817,3 +27817,118 @@ body.head-tag-style :is(.markdown-preview-view, .markdown-rendered) :is(h1, h2, 
 body:not(.remove-selectionbackground) .markdown-source-view.mod-cm6 .cm-editor .cm-selectionBackground {
   background: transparent;
 }
+
+/**** Bases start ****/
+
+/*=== Bases 表格视图 ===*/
+
+.bases-table-container {
+  border-radius: var(--bases-table-container-border-radius);
+  border: var(--bases-table-container-border-width) solid var(--bases-table-border-color);
+}
+
+.bases-table-header {
+  font-weight: var(--bases-table-header-weight);
+  color: var(--bases-table-header-color);
+  background: var(--bases-table-header-background);
+}
+
+.bases-table-header:hover {
+  background: var(--bases-table-header-background-hover);
+}
+
+.bases-tbody .bases-tr:nth-child(even) {
+  background: var(--bases-table-stripe-color, rgba(0,0,0,0.02));
+}
+
+.bases-tr:hover,
+.bases-tbody .bases-tr:nth-child(even):hover {
+  background: var(--bases-table-row-background-hover) !important;
+}
+
+.bases-table-active-cell {
+  box-shadow: var(--bases-table-cell-shadow-active);
+  background: var(--bases-table-cell-background-active);
+}
+
+/*=== Bases 卡片视图 ===*/
+
+.bases-cards-container {
+  padding: 8px;
+}
+
+.bases-cards-item {
+  background: var(--background-primary);
+  border: 1px solid var(--bases-table-border-color);
+  border-radius: 8px;
+  box-shadow: 0 1px 2px rgba(0,0,0,0.06);
+  transition: box-shadow 0.2s ease, transform 0.2s ease;
+  overflow: hidden;
+}
+
+.bases-cards-item:hover {
+  box-shadow: 0 4px 12px rgba(0,0,0,0.1);
+  transform: translateY(-1px);
+  overflow: visible !important;
+}
+
+.bases-cards-item:hover .bases-cards-property {
+  overflow: visible !important;
+}
+
+.bases-cards-cover {
+  background: linear-gradient(135deg, var(--background-secondary), var(--background-secondary-alt));
+  min-height: 40px;
+}
+
+.bases-cards-property {
+  padding: 2px 10px;
+}
+
+.bases-cards-property.mod-title {
+  border-bottom: 1px solid var(--bases-table-border-color);
+  margin-bottom: 2px;
+}
+
+.bases-cards-property.mod-title .bases-cards-line {
+  font-weight: 600;
+  color: var(--text-accent);
+}
+
+.bases-cards-label {
+  font-size: 0.75em;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  line-height: 1.4;
+}
+
+.bases-cards-line {
+  font-size: 0.875em;
+  color: var(--text-normal);
+  line-height: 1.5;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  max-width: 100%;
+}
+
+.bases-cards-line:hover {
+  overflow: visible;
+  white-space: normal;
+  word-break: break-word;
+  height: auto;
+  max-height: 200px;
+  overflow-y: auto;
+  position: relative;
+  z-index: 20;
+  background: var(--background-primary);
+  border-radius: 4px;
+  padding: 4px 8px;
+  margin: -4px -8px;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.18);
+  max-width: 100%;
+  min-width: 100%;
+}
+
+/**** Bases end ****/

--- a/obsidian.css
+++ b/obsidian.css
@@ -7513,26 +7513,6 @@ body.color-scheme-options-autumn-topaz.theme-light {
 
   --activeline-background: var(--bg-color2);
 
-  /*Bases - color-base*/
-  --color-base-00: #fafaf3;
-  --color-base-05: #f4f4ed;
-  --color-base-10: #eeeee6;
-  --color-base-20: #e6e6dd;
-  --color-base-25: #dbdbd2;
-  --color-base-30: #d0d0c6;
-  --color-base-35: #c3c3b8;
-  --color-base-40: #b3b3a7;
-  --color-base-50: #9a9a8e;
-  --color-base-60: #727267;
-  --color-base-70: #515149;
-  --color-base-100: #2b2b26;
-
-  /*Bases - autumn tweaks*/
-  --bases-table-border-color: #e0d5c0;
-  --bases-table-header-color: var(--deep-color);
-  --bases-table-header-background: var(--bg-color2);
-  --bases-table-row-background-hover: var(--color1);
-
   --table-color-calendar-2: rgb(222, 236, 182);
   --table-color-rgb: 222, 236, 182;
 }
@@ -7718,24 +7698,6 @@ body.color-scheme-options-autumn-topaz.theme-dark {
   --checkbox-color-0: var(--main-color);
 
   --activeline-background: var(--bg-color2);
-
-  /*Bases - color-base*/
-  --color-base-00: #222222;
-  --color-base-05: #252525;
-  --color-base-10: #282828;
-  --color-base-20: #2c2c2c;
-  --color-base-25: #323232;
-  --color-base-30: #3a3a3a;
-  --color-base-35: #434343;
-  --color-base-40: #585858;
-  --color-base-50: #6a6a6a;
-  --color-base-60: #9a9a9a;
-  --color-base-70: #b5b5b5;
-  --color-base-100: #dcdcdc;
-
-  /*Bases - autumn tweaks*/
-  --bases-table-header-background: #333333;
-  --bases-table-row-background-hover: #2a2a2a;
 
   --table-color-calendar-2: rgb(81, 165, 39);
   --table-color-rgb: 81, 165, 39;
@@ -24844,7 +24806,7 @@ body:not(.default-loading-page).theme-light .progress-bar {
 body:not(.default-loading-page).loading-animation-cat .progress-bar-message::before {
   content: "GIF creator: Jake Fleming";
   display: block;
-  background: url(https://cdn.dribbble.com/users/53712/screenshots/9948351/media/2397850c7727f8e70b0ec50b5a83fe76.gif) no-repeat center/cover;
+  background: no-repeat center/cover url(https://cdn.dribbble.com/users/53712/screenshots/9948351/media/2397850c7727f8e70b0ec50b5a83fe76.gif);
   width: 800px;
   height: 500px;
   margin-top: -20px;
@@ -27817,118 +27779,3 @@ body.head-tag-style :is(.markdown-preview-view, .markdown-rendered) :is(h1, h2, 
 body:not(.remove-selectionbackground) .markdown-source-view.mod-cm6 .cm-editor .cm-selectionBackground {
   background: transparent;
 }
-
-/**** Bases start ****/
-
-/*=== Bases 表格视图 ===*/
-
-.bases-table-container {
-  border-radius: var(--bases-table-container-border-radius);
-  border: var(--bases-table-container-border-width) solid var(--bases-table-border-color);
-}
-
-.bases-table-header {
-  font-weight: var(--bases-table-header-weight);
-  color: var(--bases-table-header-color);
-  background: var(--bases-table-header-background);
-}
-
-.bases-table-header:hover {
-  background: var(--bases-table-header-background-hover);
-}
-
-.bases-tbody .bases-tr:nth-child(even) {
-  background: var(--bases-table-stripe-color, rgba(0,0,0,0.02));
-}
-
-.bases-tr:hover,
-.bases-tbody .bases-tr:nth-child(even):hover {
-  background: var(--bases-table-row-background-hover) !important;
-}
-
-.bases-table-active-cell {
-  box-shadow: var(--bases-table-cell-shadow-active);
-  background: var(--bases-table-cell-background-active);
-}
-
-/*=== Bases 卡片视图 ===*/
-
-.bases-cards-container {
-  padding: 8px;
-}
-
-.bases-cards-item {
-  background: var(--background-primary);
-  border: 1px solid var(--bases-table-border-color);
-  border-radius: 8px;
-  box-shadow: 0 1px 2px rgba(0,0,0,0.06);
-  transition: box-shadow 0.2s ease, transform 0.2s ease;
-  overflow: hidden;
-}
-
-.bases-cards-item:hover {
-  box-shadow: 0 4px 12px rgba(0,0,0,0.1);
-  transform: translateY(-1px);
-  overflow: visible !important;
-}
-
-.bases-cards-item:hover .bases-cards-property {
-  overflow: visible !important;
-}
-
-.bases-cards-cover {
-  background: linear-gradient(135deg, var(--background-secondary), var(--background-secondary-alt));
-  min-height: 40px;
-}
-
-.bases-cards-property {
-  padding: 2px 10px;
-}
-
-.bases-cards-property.mod-title {
-  border-bottom: 1px solid var(--bases-table-border-color);
-  margin-bottom: 2px;
-}
-
-.bases-cards-property.mod-title .bases-cards-line {
-  font-weight: 600;
-  color: var(--text-accent);
-}
-
-.bases-cards-label {
-  font-size: 0.75em;
-  color: var(--text-muted);
-  text-transform: uppercase;
-  letter-spacing: 0.5px;
-  line-height: 1.4;
-}
-
-.bases-cards-line {
-  font-size: 0.875em;
-  color: var(--text-normal);
-  line-height: 1.5;
-  overflow: hidden;
-  white-space: nowrap;
-  text-overflow: ellipsis;
-  max-width: 100%;
-}
-
-.bases-cards-line:hover {
-  overflow: visible;
-  white-space: normal;
-  word-break: break-word;
-  height: auto;
-  max-height: 200px;
-  overflow-y: auto;
-  position: relative;
-  z-index: 20;
-  background: var(--background-primary);
-  border-radius: 4px;
-  padding: 4px 8px;
-  margin: -4px -8px;
-  box-shadow: 0 2px 8px rgba(0,0,0,0.18);
-  max-width: 100%;
-  min-width: 100%;
-}
-
-/**** Bases end ****/

--- a/obsidian.css
+++ b/obsidian.css
@@ -7513,6 +7513,26 @@ body.color-scheme-options-autumn-topaz.theme-light {
 
   --activeline-background: var(--bg-color2);
 
+  /*Bases - color-base*/
+  --color-base-00: #fafaf3;
+  --color-base-05: #f4f4ed;
+  --color-base-10: #eeeee6;
+  --color-base-20: #e6e6dd;
+  --color-base-25: #dbdbd2;
+  --color-base-30: #d0d0c6;
+  --color-base-35: #c3c3b8;
+  --color-base-40: #b3b3a7;
+  --color-base-50: #9a9a8e;
+  --color-base-60: #727267;
+  --color-base-70: #515149;
+  --color-base-100: #2b2b26;
+
+  /*Bases - autumn tweaks*/
+  --bases-table-border-color: #e0d5c0;
+  --bases-table-header-color: var(--deep-color);
+  --bases-table-header-background: var(--bg-color2);
+  --bases-table-row-background-hover: var(--color1);
+
   --table-color-calendar-2: rgb(222, 236, 182);
   --table-color-rgb: 222, 236, 182;
 }
@@ -7698,6 +7718,24 @@ body.color-scheme-options-autumn-topaz.theme-dark {
   --checkbox-color-0: var(--main-color);
 
   --activeline-background: var(--bg-color2);
+
+  /*Bases - color-base*/
+  --color-base-00: #222222;
+  --color-base-05: #252525;
+  --color-base-10: #282828;
+  --color-base-20: #2c2c2c;
+  --color-base-25: #323232;
+  --color-base-30: #3a3a3a;
+  --color-base-35: #434343;
+  --color-base-40: #585858;
+  --color-base-50: #6a6a6a;
+  --color-base-60: #9a9a9a;
+  --color-base-70: #b5b5b5;
+  --color-base-100: #dcdcdc;
+
+  /*Bases - autumn tweaks*/
+  --bases-table-header-background: #333333;
+  --bases-table-row-background-hover: #2a2a2a;
 
   --table-color-calendar-2: rgb(81, 165, 39);
   --table-color-rgb: 81, 165, 39;
@@ -24806,7 +24844,7 @@ body:not(.default-loading-page).theme-light .progress-bar {
 body:not(.default-loading-page).loading-animation-cat .progress-bar-message::before {
   content: "GIF creator: Jake Fleming";
   display: block;
-  background: no-repeat center/cover url(https://cdn.dribbble.com/users/53712/screenshots/9948351/media/2397850c7727f8e70b0ec50b5a83fe76.gif);
+  background: url(https://cdn.dribbble.com/users/53712/screenshots/9948351/media/2397850c7727f8e70b0ec50b5a83fe76.gif) no-repeat center/cover;
   width: 800px;
   height: 500px;
   margin-top: -20px;

--- a/theme.css
+++ b/theme.css
@@ -5999,7 +5999,7 @@ body.all-dark-pdf .print,
   --bases-table-group-background: transparent;
   --bases-table-row-background-hover: hsla(var(--accent-h), var(--accent-s), var(--accent-l), 0.15);
   --bases-table-text-size: var(--font-text-size);
-  --bases-table-cell-background-active: color-mix(in srgb, var(--text-accent-hover) 25%, transparent);
+  --bases-table-cell-background-active: color-mix(in srgb, var(--text-accent-hover) 18%, transparent);
   --bases-table-cell-shadow-active: 0 0 0 1px var(--interactive-accent);
 	--bases-card-shadow: var(--background-modifier-box-shadow);
 	--bases-card-line-hover: var(--background-primary-alt);
@@ -6369,7 +6369,7 @@ body.all-dark-pdf .print,
   --bases-table-group-background: transparent;
 	--bases-table-row-background-hover: hsla(var(--accent-h), var(--accent-s), var(--accent-l), 0.18);
 	--bases-table-text-size: var(--font-text-size);
-  --bases-table-cell-background-active: color-mix(in srgb, var(--text-accent-hover) 25%, transparent);
+  --bases-table-cell-background-active: color-mix(in srgb, var(--text-accent-hover) 18%, transparent);
   --bases-table-cell-shadow-active: 0 0 0 1px var(--interactive-accent);
 	--bases-card-shadow: var(--background-modifier-box-shadow);
 	--bases-card-line-hover: var(--background-primary-alt);

--- a/theme.css
+++ b/theme.css
@@ -5999,7 +5999,7 @@ body.all-dark-pdf .print,
   --bases-table-group-background: transparent;
   --bases-table-row-background-hover: hsla(var(--accent-h), var(--accent-s), var(--accent-l), 0.15);
   --bases-table-text-size: var(--font-text-size);
-  --bases-table-cell-background-active: var(--text-accent-hover);
+  --bases-table-cell-background-active: color-mix(in srgb, var(--text-accent-hover) 25%, transparent);
   --bases-table-cell-shadow-active: 0 0 0 1px var(--interactive-accent);
 	--bases-card-shadow: var(--background-modifier-box-shadow);
 	--bases-card-line-hover: var(--background-primary-alt);
@@ -6369,7 +6369,7 @@ body.all-dark-pdf .print,
   --bases-table-group-background: transparent;
 	--bases-table-row-background-hover: hsla(var(--accent-h), var(--accent-s), var(--accent-l), 0.18);
 	--bases-table-text-size: var(--font-text-size);
-  --bases-table-cell-background-active: var(--text-accent-hover);
+  --bases-table-cell-background-active: color-mix(in srgb, var(--text-accent-hover) 25%, transparent);
   --bases-table-cell-shadow-active: 0 0 0 1px var(--interactive-accent);
 	--bases-card-shadow: var(--background-modifier-box-shadow);
 	--bases-card-line-hover: var(--background-primary-alt);

--- a/theme.css
+++ b/theme.css
@@ -5759,7 +5759,7 @@ body.all-dark-pdf .print,
   --h5-color: var(--print-h5-color,hsl(258, 79%, 77%));
   --h6-color: var(--print-h6-color,hsl(290, 85%, 81%));
 
-   --hr-color:var(--color-base-10);
+  --hr-color:var(--color-base-10);
   --graph-text-color: #B5B5B5;
   --graph-tag: #88d842bb;
   --graph-attach: #b2cfe0bb;
@@ -6001,6 +6001,8 @@ body.all-dark-pdf .print,
   --bases-table-text-size: var(--font-text-size);
   --bases-table-cell-background-active: var(--text-accent-hover);
   --bases-table-cell-shadow-active: 0 0 0 1px var(--interactive-accent);
+	--bases-card-shadow: var(--background-modifier-box-shadow);
+	--bases-card-line-hover: var(--background-primary-alt);
 }
 
 .theme-light {
@@ -6369,6 +6371,8 @@ body.all-dark-pdf .print,
 	--bases-table-text-size: var(--font-text-size);
   --bases-table-cell-background-active: var(--text-accent-hover);
   --bases-table-cell-shadow-active: 0 0 0 1px var(--interactive-accent);
+	--bases-card-shadow: var(--background-modifier-box-shadow);
+	--bases-card-line-hover: var(--background-primary-alt);
 }
 
 body.color-scheme-options-avocado-topaz .theme-light,
@@ -8672,17 +8676,17 @@ body.color-scheme-options-autumn-topaz.theme-light {
 
   /*Bases - color-base*/
   --color-base-01: #bfb9a0;
-  --color-base-02: #c5b896;
+  --color-base-02: #f0f0e9;
   --color-base-03: #aaa;
-  --color-base-20: #e6e6dd;
-  --color-base-25: #dbdbd2;
-  --color-base-30: #d0d0c6;
-  --color-base-35: #c3c3b8;
-  --color-base-40: #b3b3a7;
-  --color-base-50: #9a9a8e;
-  --color-base-60: #727267;
-  --color-base-70: #515149;
-  --color-base-100: #2b2b26;
+  --color-base-04: #e6e6dd;
+  --color-base-05: #dbdbd2;
+  --color-base-06: #d0d0c6;
+  --color-base-07: #c3c3b8;
+  --color-base-08: #b3b3a7;
+  --color-base-09: #9a9a8e;
+  --color-base-10: #727267;
+  --color-base-11: #515149;
+  --color-base-12: #2b2b26;
 
   /*Bases Autumn tweak*/
   --bases-table-header-color: var(--deep-color);
@@ -8690,6 +8694,7 @@ body.color-scheme-options-autumn-topaz.theme-light {
   --bases-table-row-background-hover: color-mix(in srgb, var(--color1) 80%, var(--color-base-03));
   --bases-table-stripe-color: color-mix(in srgb, var(--color2) 20%, transparent);
 	--bases-table-group-background: color-mix(in srgb, var(--color2), white 50%);
+	--background-primary-alt: var(--color-base-02);
 
 }
 
@@ -29883,15 +29888,16 @@ body.enable-alternative-checkboxes li[data-task=U] > p > input:checked {
 
 .bases-cards-container {
   padding: 8px;
+	overflow: visible;
 }
 
 .bases-cards-item {
   background: var(--background-primary);
   border: 1px solid var(--bases-table-border-color);
   border-radius: 8px;
-  box-shadow: 0 1px 3px rgba(0,0,0,0.09);
+  box-shadow: 0 1px 6px var(--bases-card-shadow);
   transition: box-shadow 0.2s ease, transform 0.2s ease;
-  overflow: hidden;
+  overflow: visible !important;
 }
 
 .bases-cards-item:hover {
@@ -29942,21 +29948,24 @@ body.enable-alternative-checkboxes li[data-task=U] > p > input:checked {
 }
 
 .bases-cards-line:hover {
-  overflow: visible;
-  white-space: normal;
-  word-break: break-word;
-  height: auto;
-  max-height: 200px;
-  overflow-y: auto;
-  position: relative;
-  z-index: 20;
-  background: var(--background-primary);
+  position: absolute;
+  top: 0;
+  left: 2px;
+  width: calc(100% - 4px);
+  height: 100%;
+  background: var(--bases-card-line-hover);
   border-radius: 4px;
-  padding: 4px 8px;
-  margin: -4px -8px;
-  box-shadow: 0 2px 8px rgba(0,0,0,0.18);
-  max-width: 100%;
-  min-width: 100%;
+  z-index: 20;
+  box-sizing: border-box;
+	box-shadow: 0 2px 8px rgba(0,0,0,0.18);
+  text-align: left;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2; /* 限制最多显示两行，超出省略号 */
+  overflow: hidden;
+  word-break: break-word;
+  overflow-wrap: break-word;
+  white-space: normal;
 }
 
 .bases-group-heading {

--- a/theme.css
+++ b/theme.css
@@ -5964,7 +5964,8 @@ body.all-dark-pdf .print,
   --bt-connected-indent-line-color: #926a6a;
   --list-colorful-marker: #ff8686;
 
-  --color-base-00: #222222;
+  /*Bases Dark*/
+	--color-base-00: #222222;
   --color-base-05: #252525;
   --color-base-10: #282828;
   --color-base-20: #2c2c2c;
@@ -5977,7 +5978,6 @@ body.all-dark-pdf .print,
   --color-base-70: #b5b5b5;
   --color-base-100: #dcdcdc;
 
-  /*Bases Dark*/
   --bases-header-border-width: 1px;
   --bases-header-height: 40px;
   --bases-header-padding-start: 8px;
@@ -6472,13 +6472,11 @@ body.color-scheme-options-avocado-topaz.theme-light {
   --mermaid-seq-dia-color: #76c8ff;
 
   /*table*/
-	--table-border-color: hsla(var(--accent-h), var(--accent-s), var(--accent-l), 0.22);
+  --table-border-color: #7d7d7d;
   --table-thead-background-color: #dbe4dac7;
   --table-hover-raw-color: #dbe4da57;
   --table-hover-color: #dbe4da37;
   --table-hover-thead-color: #dbe4da;
-	--table-color-calendar-2: rgb(182, 221, 191);
-  --table-color-rgb: 182, 221, 191;
 
   /*calendar*/
   --calendar-week-color: #48b432;
@@ -6517,6 +6515,9 @@ body.color-scheme-options-avocado-topaz.theme-light {
   --checkbox-color-4: #fffbd4;
   --checkbox-color-5: #ad7fbf;
   --checkbox-color-6: #5f5f5f;
+
+  --table-color-calendar-2: rgb(182, 221, 191);
+  --table-color-rgb: 182, 221, 191;
 
   /*Bases 继承默认主题*/
 
@@ -6579,7 +6580,6 @@ body.color-scheme-options-avocado-topaz.theme-dark {
 
   /*table*/
   --table-thead-background-color: #557f5c43;
-	--table-border-color: hsla(var(--accent-h), var(--accent-s), var(--accent-l), 0.22);
   --table-hover-raw-color: #557f5c23;
   --table-hover-color: #557f5c23;
   --table-hover-thead-color: #557f5c53;
@@ -6627,7 +6627,7 @@ body.color-scheme-options-avocado-topaz.theme-dark {
   --table-color-rgb: 5, 158, 5;
   --divider-color: #000000;
 
-  /*Bases tweak inherits default dark theme*/
+  /*Bases 继承默认主题*/
 
 }
 
@@ -6705,7 +6705,7 @@ body.color-scheme-options-monochrome-topaz.theme-dark {
   --mermaid-seq-dia-color: #1371be;
 
   /* table */
-	--table-border-color: hsla(var(--accent-h), var(--accent-s), var(--accent-l), 0.22);
+	--table-border-color: #878787;
   --table-thead-background-color: #b3b3b363;
   --table-hover-raw-color: #4040401c;
   --table-hover-color: #59595947;
@@ -6831,7 +6831,7 @@ body.color-scheme-options-monochrome-topaz.theme-light {
   --mermaid-seq-dia-color: #76c8ff;
 
   /*table*/
-  --table-border-color: hsla(var(--accent-h), var(--accent-s), var(--accent-l), 0.22);
+  --table-border-color: #7d7d7d;
   --table-thead-background-color: #bdbdbdc7;
   --table-hover-raw-color: #f0f0f063;
   --table-hover-color: #e3e3e354;
@@ -6981,7 +6981,7 @@ body.color-scheme-options-pink-topaz.theme-light {
   --mermaid-seq-dia-color: #76c8ff;
 
   /*table*/
-	--table-border-color: hsla(var(--accent-h), var(--accent-s), var(--accent-l), 0.22);
+  --table-border-color: #7d7d7d;
   --table-thead-background-color: #fad1e96f;
   --table-hover-raw-color: #fad1e92f;
   --table-hover-color: #fad1e92f;
@@ -7126,7 +7126,6 @@ body.color-scheme-options-pink-topaz.theme-dark {
   --mermaid-seq-dia-color: #1371be;
 
   /*table*/
-	--table-border-color: hsla(var(--accent-h), var(--accent-s), var(--accent-l), 0.22);
   --table-thead-background-color: #a76c8f45;
   --table-hover-raw-color: #a76c8f25;
   --table-hover-color: #a76c8f2b;
@@ -7268,7 +7267,6 @@ body.color-scheme-options-topaz-nord.theme-dark {
   --list-ol-hover: var(--nord7);
 
 	/* table */
-	--table-border-color: hsla(var(--accent-h), var(--accent-s), var(--accent-l), 0.22);
   --table-thead-background-color: var(--nord9-2);
   --table-hover-raw-color: var(--nord9-2);
   --table-hover-color: var(--nord9-2);
@@ -7438,7 +7436,6 @@ body.color-scheme-options-topaz-nord.theme-light {
   --list-ol-hover: var(--nord7);
 
 	/* table */
-	--table-border-color: hsla(var(--accent-h), var(--accent-s), var(--accent-l), 0.22);
   --table-thead-background-color: var(--nord9-2);
   --table-hover-raw-color: var(--nord9-2);
   --table-hover-color: var(--nord9-2);
@@ -7560,7 +7557,7 @@ body.color-scheme-options-flamingo.theme-light {
 	/* table */
   --table-background-color: #ffdece;
   --table-background-color-odd: #ffdece;
-  --table-border-color: hsla(var(--accent-h), var(--accent-s), var(--accent-l), 0.22);
+  --table-border-color: #fd355a;
   --table-thead-background-color: #f5a7a2;
   --table-hover-color: #f5a7a2;
   --table-hover-thead-color: #f5a7a2;
@@ -7705,7 +7702,7 @@ body.color-scheme-options-flamingo.theme-dark {
 	/* table */
   --table-background-color: #212121;
   --table-background-color-odd: transparent;
-  --table-border-color: hsla(var(--accent-h), var(--accent-s), var(--accent-l), 0.22);
+  --table-border-color: #ffebec;
   --table-thead-background-color: #f39ba0ad;
   --table-hover-raw-color: #292929;
   --table-hover-color: #ffccbc0a;
@@ -7981,7 +7978,7 @@ body.color-scheme-options-honey-milk-topaz.theme-light {
   /*table*/
   --table-background-color: var(--bg-color2);
   --table-background-color-odd: #ffffffaf;
-  --table-border-color: hsla(var(--accent-h), var(--accent-s), var(--accent-l), 0.22);
+  --table-border-color: #7d7d7d;
   --table-thead-background-color: var(--color1);
   --table-hover-raw-color: var(--color2);
   --table-hover-color: var(--color1);
@@ -8135,7 +8132,7 @@ body.color-scheme-options-honey-milk-topaz.theme-dark {
 	/* table */
   --table-background-color: var(--bg-color2);
   --table-background-color-odd: var(--bg-color);
-  --table-border-color: hsla(var(--accent-h), var(--accent-s), var(--accent-l), 0.22);
+  --table-border-color: #878787;
   --table-thead-background-color:  var(--color11);
   --table-hover-raw-color: var(--color10);
   --table-hover-color: var(--color11);;
@@ -8312,7 +8309,7 @@ body.color-scheme-options-chocolate-topaz.theme-light {
   /*table*/
   --table-background-color: var(--bg-color2);
   --table-background-color-odd: var(--bg-color);
-  --table-border-color: hsla(var(--accent-h), var(--accent-s), var(--accent-l), 0.22);
+  --table-border-color: #7d7d7d;
   --table-thead-background-color: var(--color1);
   --table-hover-raw-color: var(--color2);
   --table-hover-color: var(--color1);
@@ -8479,7 +8476,7 @@ body.color-scheme-options-chocolate-topaz.theme-dark {
   /*table*/
   --table-background-color: var(--bg-color2);
   --table-background-color-odd: var(--bg-color);
-  --table-border-color: hsla(var(--accent-h), var(--accent-s), var(--accent-l), 0.22);
+  --table-border-color: #878787;
   --table-thead-background-color:  var(--color11);
   --table-hover-raw-color: var(--color10);
   --table-hover-color: var(--color11);;
@@ -8727,9 +8724,6 @@ body.color-scheme-options-autumn-topaz.theme-dark {
   --text-muted: #8a8a8a;  /*muted 文字颜色*/
   --text-faint: #797979;  /*faint 文字颜色*/
   --text-folder-file: #b3b3b3; /*文件夹、文件 文字颜色*/
-  --accent-h: 84;
-  --accent-s: 100%;
-  --accent-l: 40%;
   --accent-strong: #f7f7f7; /*加粗 文字颜色*/
   --accent-em: #a4ca8e; /*斜体 文字颜色*/
 
@@ -8792,7 +8786,7 @@ body.color-scheme-options-autumn-topaz.theme-dark {
   /*table*/
   --table-background-color: var(--bg-color2);
   --table-background-color-odd: var(--bg-color);
-	--table-border-color: hsla(var(--accent-h), var(--accent-s), var(--accent-l), 0.22);
+  --table-border-color: #878787;
   --table-thead-background-color:  var(--color11);
   --table-hover-raw-color: var(--color10);
   --table-hover-color: var(--color11);;
@@ -8832,9 +8826,8 @@ body.color-scheme-options-autumn-topaz.theme-dark {
   /*checkbox*/
   --checkbox-color-0: var(--main-color);
 
-  /*Bases Autumn 深色模式 tweak*/
-  --bases-table-header-color: var(--low-color);
-	
+  /*Bases 继承默认主题*/
+
 }
 
 body.color-scheme-options-autumn-topaz #calendar-container {
@@ -8948,7 +8941,7 @@ body.color-scheme-options-lillimon-topaz.theme-light {
   /*table*/
   --table-background-color: var(--bg-color2);
   --table-background-color-odd: var(--bg-color);
-  --table-border-color: hsla(var(--accent-h), var(--accent-s), var(--accent-l), 0.22);
+  --table-border-color: #7d7d7d;
   --table-thead-background-color: var(--color1);
   --table-hover-raw-color: var(--color2);
   --table-hover-color: var(--color1);
@@ -9075,7 +9068,7 @@ body.color-scheme-options-lillimon-topaz.theme-dark {
   /*table*/
   --table-background-color: var(--bg-color2);
   --table-background-color-odd: var(--bg-color);
-  --table-border-color: hsla(var(--accent-h), var(--accent-s), var(--accent-l), 0.22);
+  --table-border-color: #878787;
   --table-thead-background-color: var(--color11);
   --table-hover-raw-color: var(--color10);
   --table-hover-color: var(--color11);
@@ -9313,20 +9306,6 @@ body.color-scheme-options-lilac.theme-light {
   --divider-color: #d7c4f2;
   --tab-stacked-shadow: #c69fd5;
 
-  /*Bases - color-base*/
-  --color-base-00: #fdf7fb;
-  --color-base-05: #f8f2f6;
-  --color-base-10: #f1ecf0;
-  --color-base-20: #e6e1e5;
-  --color-base-25: #dbd6da;
-  --color-base-30: #d0cccf;
-  --color-base-35: #bfbabd;
-  --color-base-40: #a4a1a3;
-  --color-base-50: #838082;
-  --color-base-60: #5d5c5d;
-  --color-base-70: #414040;
-  --color-base-100: #202020;
-
   /*Bases 继承默认主题*/
 	
 }
@@ -9432,7 +9411,7 @@ body.color-scheme-options-lilac.theme-dark {
   /*table*/
   --table-background-color: #58266e;
   --table-background-color-odd: #0000001c;
-  --table-border-color: hsla(var(--accent-h), var(--accent-s), var(--accent-l), 0.22);
+  --table-border-color: #ac9494;
   --table-thead-background-color: #4332ddc2;
   --table-hover-raw-color: #08569a21;
   --table-hover-color: #4125a5a1;
@@ -9676,7 +9655,6 @@ body.color-scheme-options-simplicity-topaz.theme-light {
   --tab-background-active: #ffffff;
   --theme-color-translucent-01: hsla(254,80%,68%,0.1);
 
-
   /*Bases 继承默认主题*/
 
 }
@@ -9759,8 +9737,6 @@ body.color-scheme-options-simplicity-topaz.theme-dark {
   --indentation-guide: var(--simple-gray-3);
   --search-result-background:var(--simple-gray-2);
   --scrollbar-bg: transparent;
-
-	--table-border-color: hsla(var(--accent-h), var(--accent-s), var(--accent-l), 0.22);
 	
   /*Bases 继承默认主题*/
 
@@ -29869,6 +29845,9 @@ body.enable-alternative-checkboxes li[data-task=U] > p > input:checked {
 }
 
 /****end checkbox****/
+
+/**** Bases start ****/
+
 /*=== Bases 表格视图 ===*/
 
 .bases-table-container {
@@ -30014,3 +29993,5 @@ body.enable-alternative-checkboxes li[data-task=U] > p > input:checked {
   padding-inline-start: var(--bases-header-padding-start, 8px);
   padding-inline-end: var(--bases-header-padding-end, 8px);
 }
+
+/**** Bases end ****/

--- a/theme.css
+++ b/theme.css
@@ -29889,7 +29889,7 @@ body.enable-alternative-checkboxes li[data-task=U] > p > input:checked {
   background: var(--background-primary);
   border: 1px solid var(--bases-table-border-color);
   border-radius: 8px;
-  box-shadow: 0 1px 2px rgba(0,0,0,0.06);
+  box-shadow: 0 1px 3px rgba(0,0,0,0.09);
   transition: box-shadow 0.2s ease, transform 0.2s ease;
   overflow: hidden;
 }
@@ -29914,7 +29914,7 @@ body.enable-alternative-checkboxes li[data-task=U] > p > input:checked {
 }
 
 .bases-cards-property.mod-title {
-  border-bottom: 1px solid var(--bases-table-border-color);
+  border-bottom: 1px solid var(--table-border-color);
   margin-bottom: 2px;
 }
 

--- a/theme.css
+++ b/theme.css
@@ -5963,6 +5963,44 @@ body.all-dark-pdf .print,
   --bt-indentation-line-image: url("");
   --bt-connected-indent-line-color: #926a6a;
   --list-colorful-marker: #ff8686;
+
+  --color-base-00: #222222;
+  --color-base-05: #252525;
+  --color-base-10: #282828;
+  --color-base-20: #2c2c2c;
+  --color-base-25: #323232;
+  --color-base-30: #3a3a3a;
+  --color-base-35: #434343;
+  --color-base-40: #585858;
+  --color-base-50: #6a6a6a;
+  --color-base-60: #9a9a9a;
+  --color-base-70: #b5b5b5;
+  --color-base-100: #dcdcdc;
+
+  /*Bases Dark*/
+  --bases-header-border-width: 1px;
+  --bases-header-height: 40px;
+  --bases-header-padding-start: 8px;
+  --bases-header-padding-end: 8px;
+  --bases-embed-border-width: 1px;
+  --bases-embed-border-color: var(--background-modifier-border);
+  --bases-embed-border-radius: 6px;
+  --bases-table-container-border-width: 1px;
+  --bases-table-container-border-radius: 6px;
+  --bases-table-header-weight: 600;
+  --bases-table-header-color: var(--deep-color);
+  --bases-table-header-background: var(--background-secondary-alt);
+  --bases-table-header-background-hover: hsla(var(--accent-h), var(--accent-s), var(--accent-l), 0.18);
+  --table-border-color: hsla(var(--accent-h), var(--accent-s), var(--accent-l), 0.20);
+  --bases-table-border-color: transparent;
+  --bases-table-column-border-width: 0px;
+  --bases-table-row-border-width: 1px;
+  --bases-table-stripe-color: hsla(var(--accent-h), var(--accent-s), var(--accent-l), 0.06);
+  --bases-table-group-background: transparent;
+  --bases-table-row-background-hover: hsla(var(--accent-h), var(--accent-s), var(--accent-l), 0.15);
+  --bases-table-text-size: var(--font-text-size);
+  --bases-table-cell-background-active: var(--text-accent-hover);
+  --bases-table-cell-shadow-active: 0 0 0 1px var(--interactive-accent);
 }
 
 .theme-light {
@@ -6306,6 +6344,31 @@ body.all-dark-pdf .print,
   --bt-indentation-line-image: url("");
   --bt-connected-indent-line-color: #FFA8A8;
   --list-colorful-marker: #fd4949;
+	
+	/*Bases*/
+  --bases-header-border-width: 1px;
+  --bases-header-height: 40px;
+  --bases-header-padding-start: 8px;
+  --bases-header-padding-end: 8px;
+  --bases-embed-border-width: 1px;
+  --bases-embed-border-color: var(--background-modifier-border);
+  --bases-embed-border-radius: 6px;
+  --bases-table-container-border-width: 1px;
+  --bases-table-container-border-radius: 6px;
+  --bases-table-header-weight: 600;
+  --bases-table-header-color: var(--deep-color);
+	--bases-table-header-background: var(--background-secondary-alt);
+  --bases-table-header-background-hover: hsla(var(--accent-h), var(--accent-s), var(--accent-l), 0.18);
+  --table-border-color: hsla(var(--accent-h), var(--accent-s), var(--accent-l), 0.20);
+  --bases-table-border-color: transparent;
+  --bases-table-column-border-width: 0px;
+  --bases-table-row-border-width: 1px;
+	--bases-table-stripe-color: hsla(var(--accent-h), var(--accent-s), var(--accent-l), 0.08);
+  --bases-table-group-background: transparent;
+	--bases-table-row-background-hover: hsla(var(--accent-h), var(--accent-s), var(--accent-l), 0.18);
+	--bases-table-text-size: var(--font-text-size);
+  --bases-table-cell-background-active: var(--text-accent-hover);
+  --bases-table-cell-shadow-active: 0 0 0 1px var(--interactive-accent);
 }
 
 body.color-scheme-options-avocado-topaz .theme-light,
@@ -6409,11 +6472,13 @@ body.color-scheme-options-avocado-topaz.theme-light {
   --mermaid-seq-dia-color: #76c8ff;
 
   /*table*/
-  --table-border-color: #7d7d7d;
+	--table-border-color: hsla(var(--accent-h), var(--accent-s), var(--accent-l), 0.22);
   --table-thead-background-color: #dbe4dac7;
   --table-hover-raw-color: #dbe4da57;
   --table-hover-color: #dbe4da37;
   --table-hover-thead-color: #dbe4da;
+	--table-color-calendar-2: rgb(182, 221, 191);
+  --table-color-rgb: 182, 221, 191;
 
   /*calendar*/
   --calendar-week-color: #48b432;
@@ -6453,8 +6518,8 @@ body.color-scheme-options-avocado-topaz.theme-light {
   --checkbox-color-5: #ad7fbf;
   --checkbox-color-6: #5f5f5f;
 
-  --table-color-calendar-2: rgb(182, 221, 191);
-  --table-color-rgb: 182, 221, 191;
+  /*Bases 继承默认主题*/
+
 }
 
 body.color-scheme-options-avocado-topaz .workspace-leaf.mod-active .view-header-title {
@@ -6514,6 +6579,7 @@ body.color-scheme-options-avocado-topaz.theme-dark {
 
   /*table*/
   --table-thead-background-color: #557f5c43;
+	--table-border-color: hsla(var(--accent-h), var(--accent-s), var(--accent-l), 0.22);
   --table-hover-raw-color: #557f5c23;
   --table-hover-color: #557f5c23;
   --table-hover-thead-color: #557f5c53;
@@ -6560,8 +6626,10 @@ body.color-scheme-options-avocado-topaz.theme-dark {
   --table-color-calendar-2: rgb(5, 158, 5);
   --table-color-rgb: 5, 158, 5;
   --divider-color: #000000;
-}
 
+  /*Bases tweak inherits default dark theme*/
+
+}
 
 body.color-scheme-options-monochrome-topaz.theme-dark {
   --background-primary: var(--background-primary-bg-4-bt,#1e1e1e);
@@ -6636,7 +6704,8 @@ body.color-scheme-options-monochrome-topaz.theme-dark {
   --mermaid-active-task-color: #187ef1;
   --mermaid-seq-dia-color: #1371be;
 
-  --table-border-color: #878787;
+  /* table */
+	--table-border-color: hsla(var(--accent-h), var(--accent-s), var(--accent-l), 0.22);
   --table-thead-background-color: #b3b3b363;
   --table-hover-raw-color: #4040401c;
   --table-hover-color: #59595947;
@@ -6669,13 +6738,15 @@ body.color-scheme-options-monochrome-topaz.theme-dark {
   --sliding-panes-header-color: #ebebeb;
   --background-4-sliding-pane: #252525ed;
 
-
-
   --color-view-header-gradient-1: #000000de;
   --color-view-header-gradient-2: #000000c0;
 
   --table-color-calendar-2: rgb(69, 69, 69);
   --table-color-rgb: 69, 69, 69;
+
+
+  /*Bases 继承默认主题*/
+
 }
 
 body.color-scheme-options-monochrome-topaz .theme-light,
@@ -6760,7 +6831,7 @@ body.color-scheme-options-monochrome-topaz.theme-light {
   --mermaid-seq-dia-color: #76c8ff;
 
   /*table*/
-  --table-border-color: #7d7d7d;
+  --table-border-color: hsla(var(--accent-h), var(--accent-s), var(--accent-l), 0.22);
   --table-thead-background-color: #bdbdbdc7;
   --table-hover-raw-color: #f0f0f063;
   --table-hover-color: #e3e3e354;
@@ -6798,6 +6869,9 @@ body.color-scheme-options-monochrome-topaz.theme-light {
 
   --table-color-calendar-2: rgb(212, 212, 212);
   --table-color-rgb: 212, 212, 212;
+
+  /*Bases 继承默认主题*/
+
 }
 
 
@@ -6907,8 +6981,7 @@ body.color-scheme-options-pink-topaz.theme-light {
   --mermaid-seq-dia-color: #76c8ff;
 
   /*table*/
-
-  --table-border-color: #7d7d7d;
+	--table-border-color: hsla(var(--accent-h), var(--accent-s), var(--accent-l), 0.22);
   --table-thead-background-color: #fad1e96f;
   --table-hover-raw-color: #fad1e92f;
   --table-hover-color: #fad1e92f;
@@ -6961,6 +7034,9 @@ body.color-scheme-options-pink-topaz.theme-light {
 
   --table-color-calendar-2: rgb(245, 214, 224);
   --table-color-rgb: 245, 214, 224;
+
+  /*Bases 继承默认主题*/
+
 }
 
 
@@ -7050,7 +7126,7 @@ body.color-scheme-options-pink-topaz.theme-dark {
   --mermaid-seq-dia-color: #1371be;
 
   /*table*/
-
+	--table-border-color: hsla(var(--accent-h), var(--accent-s), var(--accent-l), 0.22);
   --table-thead-background-color: #a76c8f45;
   --table-hover-raw-color: #a76c8f25;
   --table-hover-color: #a76c8f2b;
@@ -7110,6 +7186,9 @@ body.color-scheme-options-pink-topaz.theme-dark {
 
   --table-color-calendar-2: rgb(215, 121, 153);
   --table-color-rgb: 215, 121, 153;
+
+	/*Bases 继承默认主题*/
+
 }
 
 body.color-scheme-options-pink-topaz.theme-light *:not(font)>em>strong,
@@ -7188,13 +7267,17 @@ body.color-scheme-options-topaz-nord.theme-dark {
   --list-ol-number-color: var(--nord9);
   --list-ol-hover: var(--nord7);
 
+	/* table */
+	--table-border-color: hsla(var(--accent-h), var(--accent-s), var(--accent-l), 0.22);
   --table-thead-background-color: var(--nord9-2);
   --table-hover-raw-color: var(--nord9-2);
   --table-hover-color: var(--nord9-2);
   --table-hover-thead-color: var(--nord9-1);
 
+	/* checkbox */
   --checkbox-color-0: var(--interactive-accent);
 
+	/* graph */
   --graph-text-color: var(--nord4);
   --graph-tag: var(--nord7);
   --graph-attach: var(--nord15);
@@ -7206,6 +7289,10 @@ body.color-scheme-options-topaz-nord.theme-dark {
   --text-search-highlight-bg: var(--nord9-1);
   --tab-outline-color: var(--nord0);
   --divider-color: var(--nord0);
+
+
+  /*Bases 继承默认主题*/
+
 }
 
 body.color-scheme-options-topaz-nord.theme-dark .titlebar-text {
@@ -7350,6 +7437,8 @@ body.color-scheme-options-topaz-nord.theme-light {
   --list-ol-number-color: var(--nord9);
   --list-ol-hover: var(--nord7);
 
+	/* table */
+	--table-border-color: hsla(var(--accent-h), var(--accent-s), var(--accent-l), 0.22);
   --table-thead-background-color: var(--nord9-2);
   --table-hover-raw-color: var(--nord9-2);
   --table-hover-color: var(--nord9-2);
@@ -7366,6 +7455,9 @@ body.color-scheme-options-topaz-nord.theme-light {
   --graph-arrow: var(--nord11);
 
   --text-search-highlight-bg: var(--nord9-2);
+
+  /*Bases 继承默认主题*/
+
 }
 
 /*@Lavi & @嘴 的Flamingo主题色（原Pink Topaz）*/
@@ -7452,6 +7544,7 @@ body.color-scheme-options-flamingo.theme-light {
   --h5-color: var(--print-h5-color,#f39ba0);
   --h6-color: var(--print-h6-color,#f39ba0);
 
+	/* graph */
   --graph-text-color: #37291a;
   --graph-tag: #ffdece;
   --graph-attach: #f5a7a2;
@@ -7459,18 +7552,28 @@ body.color-scheme-options-flamingo.theme-light {
   --graph-line: #fea2c2;
   --graph-unresolved: #E87659;
   --graph-arrow: #980000;
+
+	/* mermaid */
   --mermaid-active-task-color: #f5a7a2;
   --mermaid-seq-dia-color: #ffdece;
+
+	/* table */
   --table-background-color: #ffdece;
   --table-background-color-odd: #ffdece;
-  --table-border-color: #fd355a;
+  --table-border-color: hsla(var(--accent-h), var(--accent-s), var(--accent-l), 0.22);
   --table-thead-background-color: #f5a7a2;
   --table-hover-color: #f5a7a2;
   --table-hover-thead-color: #f5a7a2;
   --table-hover-raw-color: #ffdece;
+	--table-color-calendar-2: rgb(214, 118, 146);
+  --table-color-rgb: 214, 118, 146;
+
+	/* calendar */
   --calendar-week-color: #f5a7a2;
   --calendar-week-hover: #ffdece;
   --calendar-week-background-color: #ffdece;
+
+	/* day planner */
   --day-planner-pie: #f5a7a2;
   --day-planner-timeline: #ffdece;
   --day-planner-line: #fd355a;
@@ -7497,10 +7600,11 @@ body.color-scheme-options-flamingo.theme-light {
   --color-view-header-gradient-1: #efe9d933;
   --color-view-header-gradient-2: #efe9d933;
 
-  --table-color-calendar-2: rgb(214, 118, 146);
-  --table-color-rgb: 214, 118, 146;
   --scrollbar-thumb-bg: #f39ba050;
   --scrollbar-active-thumb-bg: #f39ba0;
+
+  /*Bases 继承默认主题*/
+
 }
 
 
@@ -7559,12 +7663,16 @@ body.color-scheme-options-flamingo.theme-dark {
 
   --search-result-file-title-color: #f39ba0;
   --background-blockquote-dark: #292929;
+
+	/* list */
   --list-ul-block-color: #f39ba0;
   --list-ul-disc-color: #f93759;
   --list-ul-hover: #ffebec;
   --list-ol-block-color: #f39ba0;
   --list-ol-number-color: #ffccbc;
   --list-ol-hover: #ffebec;
+	
+	/* tag */
   --stag1: #f39ba0;
   --stag2: #ffccbc;
   --stag3: #ffebec;
@@ -7581,6 +7689,7 @@ body.color-scheme-options-flamingo.theme-dark {
   --h5-color: var(--print-h5-color,#ffccbc);
   --h6-color: var(--print-h6-color,#ffccbc);
 
+	/* graph */
   --graph-text-color: #efe9d9;
   --graph-tag: #f39ba0;
   --graph-attach: #ffebec;
@@ -7588,23 +7697,35 @@ body.color-scheme-options-flamingo.theme-dark {
   --graph-line: #ffc3bc;
   --graph-unresolved: #ffccbc;
   --graph-arrow: #ffc3bc;
+
+	/* mermaid */
   --mermaid-active-task-color: #F39BA4;
   --mermaid-seq-dia-color: #ffebec;
+
+	/* table */
   --table-background-color: #212121;
   --table-background-color-odd: transparent;
-  --table-border-color: #ffebec;
+  --table-border-color: hsla(var(--accent-h), var(--accent-s), var(--accent-l), 0.22);
   --table-thead-background-color: #f39ba0ad;
   --table-hover-raw-color: #292929;
   --table-hover-color: #ffccbc0a;
   --table-hover-thead-color: #f39ba0;
+	--table-color-calendar-2: rgb(215, 86, 125);
+  --table-color-rgb: 215, 86, 125;
+
+	/* calendar */
   --calendar-week-color: #ffccbc;
   --calendar-week-hover: #f39ba0;
   --calendar-week-background-color: transparent;
+
+	/* day planner */
   --day-planner-pie: #ffccbc;
   --day-planner-timeline: #ff9b7c;
   --day-planner-line: #f39ba0;
   --day-planner-dot: #ffebec;
   --day-planner-item-hover: #f39ba0;
+
+	/* event */
   --event-item-color9: #ffc3bc;
   --event-item-color8: #ffbcbc;
   --event-item-color10: #ffccbc;
@@ -7626,10 +7747,11 @@ body.color-scheme-options-flamingo.theme-dark {
   --color-view-header-gradient-1: #21212122;
   --color-view-header-gradient-2: #21212122;
 
-  --table-color-calendar-2: rgb(215, 86, 125);
-  --table-color-rgb: 215, 86, 125;
   --scrollbar-thumb-bg: #e2bdbd50;
   --scrollbar-active-thumb-bg: #e2bdbd;
+
+  /*Bases 继承默认主题*/
+
 }
 
 body.color-scheme-options-flamingo.theme-light #calendar-container {
@@ -7859,7 +7981,7 @@ body.color-scheme-options-honey-milk-topaz.theme-light {
   /*table*/
   --table-background-color: var(--bg-color2);
   --table-background-color-odd: #ffffffaf;
-  --table-border-color: #7d7d7d;
+  --table-border-color: hsla(var(--accent-h), var(--accent-s), var(--accent-l), 0.22);
   --table-thead-background-color: var(--color1);
   --table-hover-raw-color: var(--color2);
   --table-hover-color: var(--color1);
@@ -7913,6 +8035,9 @@ body.color-scheme-options-honey-milk-topaz.theme-light {
 
   --table-color-calendar-2: rgb(242, 235, 207);
   --table-color-rgb: 242, 235, 207;
+
+  /*Bases 继承默认主题*/
+
 }
 
 
@@ -8007,9 +8132,10 @@ body.color-scheme-options-honey-milk-topaz.theme-dark {
   --mermaid-active-task-color: var(--low-color);
   --mermaid-seq-dia-color: var(--high-color);
 
+	/* table */
   --table-background-color: var(--bg-color2);
   --table-background-color-odd: var(--bg-color);
-  --table-border-color: #878787;
+  --table-border-color: hsla(var(--accent-h), var(--accent-s), var(--accent-l), 0.22);
   --table-thead-background-color:  var(--color11);
   --table-hover-raw-color: var(--color10);
   --table-hover-color: var(--color11);;
@@ -8049,6 +8175,10 @@ body.color-scheme-options-honey-milk-topaz.theme-dark {
 
   --table-color-calendar-2: rgb(120, 104, 38);
   --table-color-rgb: 120, 104, 38;
+
+
+  /*Bases 继承默认主题*/
+
 }
 
 body.color-scheme-options-honey-milk-topaz #calendar-container {
@@ -8182,11 +8312,13 @@ body.color-scheme-options-chocolate-topaz.theme-light {
   /*table*/
   --table-background-color: var(--bg-color2);
   --table-background-color-odd: var(--bg-color);
-  --table-border-color: #7d7d7d;
+  --table-border-color: hsla(var(--accent-h), var(--accent-s), var(--accent-l), 0.22);
   --table-thead-background-color: var(--color1);
   --table-hover-raw-color: var(--color2);
   --table-hover-color: var(--color1);
   --table-hover-thead-color: var(--color2);
+	--table-color-calendar-2: rgb(76, 52, 16);
+  --table-color-rgb: 76, 52, 16;
 
   /*calendar*/
   --calendar-week-color: var(--high-color);
@@ -8221,8 +8353,8 @@ body.color-scheme-options-chocolate-topaz.theme-light {
   /*checkbox*/
   --checkbox-color-0: var(--main-color);
 
-  --table-color-calendar-2: rgb(76, 52, 16);
-  --table-color-rgb: 76, 52, 16;
+  /*Bases 继承默认主题*/
+  
 }
 
 body.color-scheme-options-chocolate-topaz.theme-dark {
@@ -8347,7 +8479,7 @@ body.color-scheme-options-chocolate-topaz.theme-dark {
   /*table*/
   --table-background-color: var(--bg-color2);
   --table-background-color-odd: var(--bg-color);
-  --table-border-color: #878787;
+  --table-border-color: hsla(var(--accent-h), var(--accent-s), var(--accent-l), 0.22);
   --table-thead-background-color:  var(--color11);
   --table-hover-raw-color: var(--color10);
   --table-hover-color: var(--color11);;
@@ -8388,6 +8520,10 @@ body.color-scheme-options-chocolate-topaz.theme-dark {
 
   --table-color-calendar-2: rgb(70, 45, 6);
   --table-color-rgb: 70, 45, 6;
+
+
+  /*Bases 继承默认主题*/
+
 }
 
 body.color-scheme-options-chocolate-topaz #calendar-container {
@@ -8496,7 +8632,9 @@ body.color-scheme-options-autumn-topaz.theme-light {
   /*table*/
   --table-background-color: var(--bg-color2);
   --table-background-color-odd: var(--bg-color);
-  --table-border-color: #7d7d7d;
+	--table-border-color: #c5b896;
+	--table-color-calendar-2: rgb(222, 236, 182);
+  --table-color-rgb: 222, 236, 182;
   --table-thead-background-color: var(--color1);
   --table-hover-raw-color: var(--color2);
   --table-hover-color: var(--color1);
@@ -8535,8 +8673,27 @@ body.color-scheme-options-autumn-topaz.theme-light {
   /*checkbox*/
   --checkbox-color-0: var(--main-color);
 
-  --table-color-calendar-2: rgb(222, 236, 182);
-  --table-color-rgb: 222, 236, 182;
+  /*Bases - color-base*/
+  --color-base-01: #bfb9a0;
+  --color-base-02: #c5b896;
+  --color-base-03: #aaa;
+  --color-base-20: #e6e6dd;
+  --color-base-25: #dbdbd2;
+  --color-base-30: #d0d0c6;
+  --color-base-35: #c3c3b8;
+  --color-base-40: #b3b3a7;
+  --color-base-50: #9a9a8e;
+  --color-base-60: #727267;
+  --color-base-70: #515149;
+  --color-base-100: #2b2b26;
+
+  /*Bases Autumn tweak*/
+  --bases-table-header-color: var(--deep-color);
+	--bases-table-header-background: var(--background-secondary-alt);
+  --bases-table-row-background-hover: color-mix(in srgb, var(--color1) 80%, var(--color-base-03));
+  --bases-table-stripe-color: color-mix(in srgb, var(--color2) 20%, transparent);
+	--bases-table-group-background: color-mix(in srgb, var(--color2), white 50%);
+
 }
 
 
@@ -8570,6 +8727,9 @@ body.color-scheme-options-autumn-topaz.theme-dark {
   --text-muted: #8a8a8a;  /*muted 文字颜色*/
   --text-faint: #797979;  /*faint 文字颜色*/
   --text-folder-file: #b3b3b3; /*文件夹、文件 文字颜色*/
+  --accent-h: 84;
+  --accent-s: 100%;
+  --accent-l: 40%;
   --accent-strong: #f7f7f7; /*加粗 文字颜色*/
   --accent-em: #a4ca8e; /*斜体 文字颜色*/
 
@@ -8632,7 +8792,7 @@ body.color-scheme-options-autumn-topaz.theme-dark {
   /*table*/
   --table-background-color: var(--bg-color2);
   --table-background-color-odd: var(--bg-color);
-  --table-border-color: #878787;
+	--table-border-color: hsla(var(--accent-h), var(--accent-s), var(--accent-l), 0.22);
   --table-thead-background-color:  var(--color11);
   --table-hover-raw-color: var(--color10);
   --table-hover-color: var(--color11);;
@@ -8672,8 +8832,9 @@ body.color-scheme-options-autumn-topaz.theme-dark {
   /*checkbox*/
   --checkbox-color-0: var(--main-color);
 
-  --table-color-calendar-2: rgb(81, 165, 39);
-  --table-color-rgb: 81, 165, 39;
+  /*Bases Autumn 深色模式 tweak*/
+  --bases-table-header-color: var(--low-color);
+	
 }
 
 body.color-scheme-options-autumn-topaz #calendar-container {
@@ -8787,7 +8948,7 @@ body.color-scheme-options-lillimon-topaz.theme-light {
   /*table*/
   --table-background-color: var(--bg-color2);
   --table-background-color-odd: var(--bg-color);
-  --table-border-color: #7d7d7d;
+  --table-border-color: hsla(var(--accent-h), var(--accent-s), var(--accent-l), 0.22);
   --table-thead-background-color: var(--color1);
   --table-hover-raw-color: var(--color2);
   --table-hover-color: var(--color1);
@@ -8825,6 +8986,9 @@ body.color-scheme-options-lillimon-topaz.theme-light {
 
   /*checkbox*/
   --checkbox-color-0: var(--magic-main-color);
+
+  /*Bases 继承默认主题*/
+  
 }
 
 
@@ -8911,7 +9075,7 @@ body.color-scheme-options-lillimon-topaz.theme-dark {
   /*table*/
   --table-background-color: var(--bg-color2);
   --table-background-color-odd: var(--bg-color);
-  --table-border-color: #878787;
+  --table-border-color: hsla(var(--accent-h), var(--accent-s), var(--accent-l), 0.22);
   --table-thead-background-color: var(--color11);
   --table-hover-raw-color: var(--color10);
   --table-hover-color: var(--color11);
@@ -8948,6 +9112,10 @@ body.color-scheme-options-lillimon-topaz.theme-dark {
 
   /*checkbox*/
   --checkbox-color-0: var(--magic-main-color);
+
+
+  /*Bases 继承默认主题*/
+
 }
 
 body.color-scheme-options-lillimon-topaz #calendar-container {
@@ -9024,6 +9192,7 @@ body.color-scheme-options-lilac.theme-light {
 
   --internal-link-color: #6203a2;
 
+	/* list */
   --list-ul: #ffffff;
   --list-ul-block-color: #7f1bb9;
   --list-ul-disc-color: #d955f3;
@@ -9034,6 +9203,7 @@ body.color-scheme-options-lilac.theme-light {
 
   --green-1: #9c30c7;
 
+	/* tag */
   --tag-text: #d2a3d4;
   --stag1: #fa8787;
   --stag1-bg: #eb2727;
@@ -9041,13 +9211,11 @@ body.color-scheme-options-lilac.theme-light {
   --stag2-bg: #ee9002;
   --stag3: #50ce3a;
   --stag3-bg: #22ac09;
-
   --tag1: #2b85ce;
   --tag2: #29b325;
   --tag3: #20b9ce;
   --tag4: #dfd331;
   --tag5: #bbbbbb;
-
   --tag-dailynote: #0077ff;
   --tag-dailynote-bg: #277CDD;
   --tag-weeklynote: #4b9fff;
@@ -9057,6 +9225,7 @@ body.color-scheme-options-lilac.theme-light {
   --tag-ideas: #ceb900;
   --tag-ideas-bg: #444444d8;
 
+	/* header */
   --h1-color: var(--print-h1-color, #6F6493);
   --h2-color: var(--print-h2-color, #724681);
   --h3-color: var(--print-h3-color, #330349);
@@ -9143,6 +9312,23 @@ body.color-scheme-options-lilac.theme-light {
 
   --divider-color: #d7c4f2;
   --tab-stacked-shadow: #c69fd5;
+
+  /*Bases - color-base*/
+  --color-base-00: #fdf7fb;
+  --color-base-05: #f8f2f6;
+  --color-base-10: #f1ecf0;
+  --color-base-20: #e6e1e5;
+  --color-base-25: #dbd6da;
+  --color-base-30: #d0cccf;
+  --color-base-35: #bfbabd;
+  --color-base-40: #a4a1a3;
+  --color-base-50: #838082;
+  --color-base-60: #5d5c5d;
+  --color-base-70: #414040;
+  --color-base-100: #202020;
+
+  /*Bases 继承默认主题*/
+	
 }
 
 
@@ -9174,12 +9360,15 @@ body.color-scheme-options-lilac.theme-dark {
 
   --strong-em-highlight-color: #9c8ce6;
 
+	/* text */
   --text-highlight-bg-h: 286;
   --text-highlight-bg-s: 40%;
   --text-highlight-bg-l: 38%;
   --text-highlight-bg-a: 0.541;
   --text-highlight-bg: hsla(var(--text-highlight-bg-h), var(--text-highlight-bg-s), var(--text-highlight-bg-l), var(--text-highlight-bg-a));
   --text-search-highlight-bg: #bb4361;
+	--text-color-code: #d58000;
+
   --strong-em-color-1: #9c8ce6;
   --strong-em-color-2: #23d05c;
 
@@ -9195,10 +9384,10 @@ body.color-scheme-options-lilac.theme-dark {
   --background-blockquote: #9191911c;
   --background-code: #1111118c;
   --background-code-2: #4c4c4cb0;
-  --text-color-code: #d58000;
-
+  
   --internal-link-color: #a360da;
 
+	/* list */
   --list-ul: #f1a8f8;
   --list-ul-block-color: #e142d9a9;
   --list-ul-disc-color: #ae63eb;
@@ -9208,6 +9397,7 @@ body.color-scheme-options-lilac.theme-dark {
   --list-ol-number-color: #b595c4;
   --list-ol-hover: #ba2cd6;
 
+	/* tag */
   --tag-text: #e4e4e4;
   --stag1: #f08383;
   --stag1-bg: #bd1919;
@@ -9242,7 +9432,7 @@ body.color-scheme-options-lilac.theme-dark {
   /*table*/
   --table-background-color: #58266e;
   --table-background-color-odd: #0000001c;
-  --table-border-color: #ac9494;
+  --table-border-color: hsla(var(--accent-h), var(--accent-s), var(--accent-l), 0.22);
   --table-thead-background-color: #4332ddc2;
   --table-hover-raw-color: #08569a21;
   --table-hover-color: #4125a5a1;
@@ -9299,6 +9489,9 @@ body.color-scheme-options-lilac.theme-dark {
   --table-color-rgb: 98, 36, 143;
 
   --tab-stacked-shadow: #240a2e;
+
+  /*Bases 继承默认主题*/
+  
 }
 
 /*分割工作区的线透明*/
@@ -9482,6 +9675,10 @@ body.color-scheme-options-simplicity-topaz.theme-light {
   --background-transparent-black-or-white-3: var(--bg-color-settings-1) !important;
   --tab-background-active: #ffffff;
   --theme-color-translucent-01: hsla(254,80%,68%,0.1);
+
+
+  /*Bases 继承默认主题*/
+
 }
 
 
@@ -9562,6 +9759,10 @@ body.color-scheme-options-simplicity-topaz.theme-dark {
   --indentation-guide: var(--simple-gray-3);
   --search-result-background:var(--simple-gray-2);
   --scrollbar-bg: transparent;
+
+	--table-border-color: hsla(var(--accent-h), var(--accent-s), var(--accent-l), 0.22);
+	
+  /*Bases 继承默认主题*/
 
 }
 
@@ -29668,4 +29869,148 @@ body.enable-alternative-checkboxes li[data-task=U] > p > input:checked {
 }
 
 /****end checkbox****/
+/*=== Bases 表格视图 ===*/
 
+.bases-table-container {
+  border-radius: var(--bases-table-container-border-radius);
+  border: var(--bases-table-container-border-width) solid var(--bases-table-border-color);
+}
+
+.bases-table-header {
+  font-weight: var(--bases-table-header-weight);
+  color: var(--bases-table-header-color);
+  background: var(--bases-table-header-background);
+}
+
+.bases-table-header:hover {
+  background: var(--bases-table-header-background-hover);
+}
+
+.bases-tbody .bases-tr:nth-child(even) {
+  background: var(--bases-table-stripe-color, rgba(0,0,0,0.02));
+}
+
+.bases-tr:hover,
+.bases-tbody .bases-tr:nth-child(even):hover {
+  background: var(--bases-table-row-background-hover) !important;
+}
+
+.bases-table-active-cell {
+  box-shadow: var(--bases-table-cell-shadow-active);
+  background: var(--bases-table-cell-background-active);
+}
+
+/*=== Bases 卡片视图 ===*/
+
+.bases-cards-container {
+  padding: 8px;
+}
+
+.bases-cards-item {
+  background: var(--background-primary);
+  border: 1px solid var(--bases-table-border-color);
+  border-radius: 8px;
+  box-shadow: 0 1px 2px rgba(0,0,0,0.06);
+  transition: box-shadow 0.2s ease, transform 0.2s ease;
+  overflow: hidden;
+}
+
+.bases-cards-item:hover {
+  box-shadow: 0 4px 12px rgba(0,0,0,0.1);
+  transform: translateY(-1px);
+  overflow: visible !important;
+}
+
+.bases-cards-item:hover .bases-cards-property {
+  overflow: visible !important;
+}
+
+.bases-cards-cover {
+  background: linear-gradient(135deg, var(--background-secondary), var(--background-secondary-alt));
+  min-height: 40px;
+}
+
+.bases-cards-property {
+  padding: 2px 10px;
+}
+
+.bases-cards-property.mod-title {
+  border-bottom: 1px solid var(--bases-table-border-color);
+  margin-bottom: 2px;
+}
+
+.bases-cards-property.mod-title .bases-cards-line {
+  font-weight: 600;
+  color: var(--text-accent);
+}
+
+.bases-cards-label {
+  font-size: 0.75em;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  line-height: 1.4;
+}
+
+.bases-cards-line {
+  font-size: 0.875em;
+  color: var(--text-normal);
+  line-height: 1.5;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  max-width: 100%;
+}
+
+.bases-cards-line:hover {
+  overflow: visible;
+  white-space: normal;
+  word-break: break-word;
+  height: auto;
+  max-height: 200px;
+  overflow-y: auto;
+  position: relative;
+  z-index: 20;
+  background: var(--background-primary);
+  border-radius: 4px;
+  padding: 4px 8px;
+  margin: -4px -8px;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.18);
+  max-width: 100%;
+  min-width: 100%;
+}
+
+.bases-group-heading {
+  font-weight: 600;
+  font-size: 0.9em;
+  color: var(--text-normal);
+  padding: 6px 0;
+  border-bottom: 1px solid var(--bases-table-border-color);
+  margin-bottom: 8px;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.bases-table > .bases-group-heading:first-of-type {
+  margin-top: 8px;
+}
+
+.bases-group-property {
+  color: var(--text-muted);
+  font-size: 0.8em;
+  font-weight: 400;
+}
+
+.bases-group-value {
+  color: var(--text-accent);
+}
+
+/*=== Bases 工具栏 ===*/
+
+.bases-header {
+  border-bottom: var(--bases-header-border-width, 1px) solid var(--bases-table-border-color);
+  min-height: var(--bases-header-height, 40px);
+  padding-inline-start: var(--bases-header-padding-start, 8px);
+  padding-inline-end: var(--bases-header-padding-end, 8px);
+}


### PR DESCRIPTION
1. 给主题添加`Bases`插件样式支持（目前仅提交表格视图和卡片视图）
2. 除了Autumn主题外其他主题默认继承浅色/深色主题的`Bases`样式；Autumn微调了表格视图表头→分组行的颜色效果
3. 各主题的内部代码注释优化