### PR TITLE
Feat/bases support

### DIFF
--- a/theme.css
+++ b/theme.css
@@ -30013,11 +30013,11 @@ body.enable-alternative-checkboxes li[data-task=U] > p > input:checked {
   padding: 0 0.3em;
 }
 
-.bases-list-item .bases-rendered-value[data-property-type] {
+.bases-list-item .bases-rendered-value {
   position: relative;
 }
 
-.bases-list-item .bases-rendered-value[data-property-type]:hover::after {
+.bases-list-item .bases-rendered-value:hover::after {
   content: attr(data-property-type);
   position: absolute;
   bottom: 100%;
@@ -30031,6 +30031,10 @@ body.enable-alternative-checkboxes li[data-task=U] > p > input:checked {
   box-shadow: 0 1px 4px rgba(0,0,0,0.12);
   z-index: 20;
   pointer-events: none;
+}
+
+.bases-list-item .bases-list-property:first-child .bases-rendered-value:hover::after {
+  content: "标题";
 }
 
 /**** Bases end ****/

--- a/theme.css
+++ b/theme.css
@@ -29937,7 +29937,6 @@ body.enable-alternative-checkboxes li[data-task=U] > p > input:checked {
   text-align: center;
   width: 100%;
   border-radius: 6px;
-	margin: -10px 0;
 }
 
 .bases-cards-item {
@@ -30024,9 +30023,7 @@ body.enable-alternative-checkboxes li[data-task=U] > p > input:checked {
 /*=== Bases 列表视图 ===*/
 
 .bases-list-group > .bases-group-heading {
-  padding: 8px 0;
-	border-radius: 6px;
-	gap: 6px;
+  border-radius: 6px;
 }
 
 .bases-list-item {

--- a/theme.css
+++ b/theme.css
@@ -29924,7 +29924,9 @@ body.enable-alternative-checkboxes li[data-task=U] > p > input:checked {
 .bases-cards-container .bases-group-heading {
   justify-content: center;
   text-align: center;
+  width: 100%;
   border-radius: 6px;
+  margin-top: 8px;
   margin-bottom: 8px;
 }
 
@@ -30022,6 +30024,7 @@ body.enable-alternative-checkboxes li[data-task=U] > p > input:checked {
 
 .bases-list-group > .bases-group-heading {
   margin-top: 8px;
+  margin-bottom: 8px;
 }
 
 .bases-list-item {

--- a/theme.css
+++ b/theme.css
@@ -29939,6 +29939,10 @@ body.enable-alternative-checkboxes li[data-task=U] > p > input:checked {
   border-radius: 6px;
 }
 
+.bases-cards-container .bases-cards-group {
+  padding-top: 8px;
+}
+
 .bases-cards-item {
   background: var(--background-primary);
   border: 1px solid var(--bases-table-border-color);
@@ -30024,6 +30028,7 @@ body.enable-alternative-checkboxes li[data-task=U] > p > input:checked {
 
 .bases-list-group > .bases-group-heading {
   border-radius: 6px;
+  margin-top: 8px;
 }
 
 .bases-list-item {

--- a/theme.css
+++ b/theme.css
@@ -29871,7 +29871,6 @@ body.enable-alternative-checkboxes li[data-task=U] > p > input:checked {
   padding: 6px 0;
   border-bottom: 1px solid var(--bases-table-border-color);
 	background: var(--bases-table-group-background);
-  margin-bottom: 8px;
   display: flex;
   align-items: center;
   gap: 6px;
@@ -29888,18 +29887,16 @@ body.enable-alternative-checkboxes li[data-task=U] > p > input:checked {
 
 /*=== Bases 工具栏 ===*/
 
-.bases-header {
-  border-bottom: var(--bases-header-border-width, 1px) solid var(--bases-table-border-color);
-  min-height: var(--bases-header-height, 40px);
-  padding-inline-start: var(--bases-header-padding-start, 8px);
-  padding-inline-end: var(--bases-header-padding-end, 8px);
-}
 
 /*=== Bases 表格视图 ===*/
 
 .bases-table-container {
   border-radius: var(--bases-table-container-border-radius);
   border: var(--bases-table-container-border-width) solid var(--bases-table-border-color);
+}
+
+.bases-table-container .bases-group-heading{
+	margin-bottom: 8px;
 }
 
 .bases-table-header {
@@ -30026,12 +30023,18 @@ body.enable-alternative-checkboxes li[data-task=U] > p > input:checked {
 
 /*=== Bases 列表视图 ===*/
 
-.bases-list-group > .bases-group-heading {
-  border-radius: 6px;
+.bases-list-container {
+	height: auto !important;
+	overflow: visible;
 }
 
 .bases-list-group {
-  box-shadow: 0 8px 0 0 var(--background-primary);
+  height: auto !important;
+}
+
+.bases-list-group > .bases-group-heading {
+  border-radius: 6px;
+	padding-left: 8px;
 }
 
 .bases-list-item {

--- a/theme.css
+++ b/theme.css
@@ -30025,7 +30025,7 @@ body.enable-alternative-checkboxes li[data-task=U] > p > input:checked {
   white-space: nowrap;
   background: var(--background-primary);
   color: var(--text-muted);
-  font-size: 0.75em;
+  font-size: 100%;
   padding: 2px 6px;
   border-radius: 4px;
   box-shadow: 0 1px 4px rgba(0,0,0,0.12);
@@ -30035,6 +30035,15 @@ body.enable-alternative-checkboxes li[data-task=U] > p > input:checked {
 
 .bases-list-item .bases-list-property:first-child .bases-rendered-value:hover::after {
   content: "标题";
+}
+
+.bases-list-group > .bases-group-heading {
+  font-size: 1.15em;
+  font-weight: 700;
+  background: var(--bases-table-header-background);
+  padding: 8px 12px;
+  border-radius: 4px;
+  margin-bottom: 4px;
 }
 
 /**** Bases end ****/

--- a/theme.css
+++ b/theme.css
@@ -30031,6 +30031,15 @@ body.enable-alternative-checkboxes li[data-task=U] > p > input:checked {
   margin-top: 8px;
 }
 
+.bases-list-group {
+  height: auto !important;
+  overflow: visible !important;
+}
+
+.bases-list-group .bases-list-group-list {
+  height: auto !important;
+}
+
 .bases-list-item {
   font-size: 110%;
 }

--- a/theme.css
+++ b/theme.css
@@ -30013,12 +30013,12 @@ body.enable-alternative-checkboxes li[data-task=U] > p > input:checked {
   padding: 0 0.3em;
 }
 
-.bases-list-item .bases-list-property {
+.bases-list-item .bases-rendered-value[data-property-type] {
   position: relative;
 }
 
-.bases-list-item .bases-list-property:hover::after {
-  content: attr(data-property);
+.bases-list-item .bases-rendered-value[data-property-type]:hover::after {
+  content: attr(data-property-type);
   position: absolute;
   bottom: 100%;
   left: 0;

--- a/theme.css
+++ b/theme.css
@@ -29926,8 +29926,7 @@ body.enable-alternative-checkboxes li[data-task=U] > p > input:checked {
   text-align: center;
   width: 100%;
   border-radius: 6px;
-  margin-top: 8px;
-  margin-bottom: 8px;
+  padding: 8px 0;
 }
 
 .bases-cards-item {
@@ -30023,8 +30022,7 @@ body.enable-alternative-checkboxes li[data-task=U] > p > input:checked {
 /*=== Bases 列表视图 ===*/
 
 .bases-list-group > .bases-group-heading {
-  margin-top: 8px;
-  margin-bottom: 8px;
+  padding: 8px 0;
 }
 
 .bases-list-item {

--- a/theme.css
+++ b/theme.css
@@ -30003,4 +30003,34 @@ body.enable-alternative-checkboxes li[data-task=U] > p > input:checked {
   padding-inline-end: var(--bases-header-padding-end, 8px);
 }
 
+/*=== Bases 列表视图 ===*/
+
+.bases-list-item {
+  font-size: 110%;
+}
+
+.bases-list-item .bases-list-separator {
+  padding: 0 0.3em;
+}
+
+.bases-list-item .bases-list-property {
+  position: relative;
+}
+
+.bases-list-item .bases-list-property:hover::after {
+  content: attr(data-property);
+  position: absolute;
+  bottom: 100%;
+  left: 0;
+  white-space: nowrap;
+  background: var(--background-primary);
+  color: var(--text-muted);
+  font-size: 0.75em;
+  padding: 2px 6px;
+  border-radius: 4px;
+  box-shadow: 0 1px 4px rgba(0,0,0,0.12);
+  z-index: 20;
+  pointer-events: none;
+}
+
 /**** Bases end ****/

--- a/theme.css
+++ b/theme.css
@@ -5982,6 +5982,8 @@ body.all-dark-pdf .print,
   --bases-header-height: 40px;
   --bases-header-padding-start: 8px;
   --bases-header-padding-end: 8px;
+	--bases-group-heading-property-size: var(--font-small-size);
+	--bases-group-heading-value-size: var(--font-small-size);
   --bases-embed-border-width: 1px;
   --bases-embed-border-color: var(--background-modifier-border);
   --bases-embed-border-radius: 6px;
@@ -6003,6 +6005,8 @@ body.all-dark-pdf .print,
   --bases-table-cell-shadow-active: 0 0 0 1px var(--interactive-accent);
 	--bases-card-shadow: var(--background-modifier-box-shadow);
 	--bases-card-line-hover: var(--background-primary-alt);
+	--bases-list-separator-color: hsla(var(--accent-h), var(--accent-s), var(--accent-l), 0.75);
+	--bases-list-separator-font-weight: bold;
 }
 
 .theme-light {
@@ -6352,6 +6356,8 @@ body.all-dark-pdf .print,
   --bases-header-height: 40px;
   --bases-header-padding-start: 8px;
   --bases-header-padding-end: 8px;
+	--bases-group-heading-property-size: var(--font-small-size);
+	--bases-group-heading-value-size: var(--font-small-size);
   --bases-embed-border-width: 1px;
   --bases-embed-border-color: var(--background-modifier-border);
   --bases-embed-border-radius: 6px;
@@ -6373,6 +6379,8 @@ body.all-dark-pdf .print,
   --bases-table-cell-shadow-active: 0 0 0 1px var(--interactive-accent);
 	--bases-card-shadow: var(--background-modifier-box-shadow);
 	--bases-card-line-hover: var(--background-primary-alt);
+	--bases-list-separator-color: hsla(var(--accent-h), var(--accent-s), var(--accent-l), 0.75);
+	--bases-list-separator-font-weight: bold;
 }
 
 body.color-scheme-options-avocado-topaz .theme-light,
@@ -29871,12 +29879,20 @@ body.enable-alternative-checkboxes li[data-task=U] > p > input:checked {
 
 .bases-group-property {
   color: var(--text-muted);
-  font-size: 0.8em;
-  font-weight: 400;
+	--bases-group-heading-value-size: 1.9em;
 }
 
 .bases-group-value {
   color: var(--text-accent);
+}
+
+/*=== Bases 工具栏 ===*/
+
+.bases-header {
+  border-bottom: var(--bases-header-border-width, 1px) solid var(--bases-table-border-color);
+  min-height: var(--bases-header-height, 40px);
+  padding-inline-start: var(--bases-header-padding-start, 8px);
+  padding-inline-end: var(--bases-header-padding-end, 8px);
 }
 
 /*=== Bases 表格视图 ===*/
@@ -29916,17 +29932,12 @@ body.enable-alternative-checkboxes li[data-task=U] > p > input:checked {
 
 /*=== Bases 卡片视图 ===*/
 
-.bases-cards-container {
-  padding: 8px;
-	overflow: visible;
-}
-
 .bases-cards-container .bases-group-heading {
   justify-content: center;
   text-align: center;
   width: 100%;
   border-radius: 6px;
-  padding: 8px 0;
+	margin: -10px 0;
 }
 
 .bases-cards-item {
@@ -30010,19 +30021,12 @@ body.enable-alternative-checkboxes li[data-task=U] > p > input:checked {
   margin-top: 8px;
 }
 
-/*=== Bases 工具栏 ===*/
-
-.bases-header {
-  border-bottom: var(--bases-header-border-width, 1px) solid var(--bases-table-border-color);
-  min-height: var(--bases-header-height, 40px);
-  padding-inline-start: var(--bases-header-padding-start, 8px);
-  padding-inline-end: var(--bases-header-padding-end, 8px);
-}
-
 /*=== Bases 列表视图 ===*/
 
 .bases-list-group > .bases-group-heading {
   padding: 8px 0;
+	border-radius: 6px;
+	gap: 6px;
 }
 
 .bases-list-item {
@@ -30030,7 +30034,9 @@ body.enable-alternative-checkboxes li[data-task=U] > p > input:checked {
 }
 
 .bases-list-item .bases-list-separator {
-  padding: 0 0.3em;
+  padding: 0 0.2em;
+	color: var(--bases-list-separator-color);
+	font-weight: var(--bases-list-separator-font-weight);
 }
 
 .bases-list-item .bases-rendered-value {

--- a/theme.css
+++ b/theme.css
@@ -30028,16 +30028,10 @@ body.enable-alternative-checkboxes li[data-task=U] > p > input:checked {
 
 .bases-list-group > .bases-group-heading {
   border-radius: 6px;
-  margin-top: 8px;
 }
 
 .bases-list-group {
-  height: auto !important;
-  overflow: visible !important;
-}
-
-.bases-list-group .bases-list-group-list {
-  height: auto !important;
+  box-shadow: 0 8px 0 0 var(--background-primary);
 }
 
 .bases-list-item {

--- a/theme.css
+++ b/theme.css
@@ -29874,6 +29874,12 @@ body.enable-alternative-checkboxes li[data-task=U] > p > input:checked {
   display: flex;
   align-items: center;
   gap: 6px;
+  transition: font-size 0.15s ease;
+}
+
+.bases-group-heading:hover {
+  font-size: 1.4em;
+  overflow: visible;
 }
 
 .bases-group-property {

--- a/theme.css
+++ b/theme.css
@@ -29891,6 +29891,15 @@ body.enable-alternative-checkboxes li[data-task=U] > p > input:checked {
 	overflow: visible;
 }
 
+.bases-cards-container > .bases-group-heading:first-of-type {
+  margin-top: 8px;
+}
+
+.bases-cards-container .bases-group-heading {
+  border-radius: 6px;
+  margin-bottom: 8px;
+}
+
 .bases-cards-item {
   background: var(--background-primary);
   border: 1px solid var(--bases-table-border-color);

--- a/theme.css
+++ b/theme.css
@@ -30038,12 +30038,17 @@ body.enable-alternative-checkboxes li[data-task=U] > p > input:checked {
 }
 
 .bases-list-group > .bases-group-heading {
-  font-size: 1.15em;
-  font-weight: 700;
-  background: var(--bases-table-header-background);
-  padding: 8px 12px;
-  border-radius: 4px;
-  margin-bottom: 4px;
+  height: var(--bases-table-row-height, 32px);
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-weight: 600;
+  font-size: 0.9em;
+  color: var(--text-normal);
+  padding: 0 12px;
+  border-bottom: 1px solid var(--bases-table-border-color);
+  margin-bottom: 0;
+  background: transparent;
 }
 
 /**** Bases end ****/

--- a/theme.css
+++ b/theme.css
@@ -29856,9 +29856,11 @@ body.enable-alternative-checkboxes li[data-task=U] > p > input:checked {
 /*=== Bases 基础设置 ===*/
 
 .bases-group-heading {
-	width: 100%;
+ 	width: 100%;
   font-weight: 600;
-  font-size: 0.9em;
+  font-size: 1.1em;
+  text-align: center;
+  justify-content: center;
   color: var(--text-normal);
   padding: 6px 0;
   border-bottom: 1px solid var(--bases-table-border-color);
@@ -29919,6 +29921,11 @@ body.enable-alternative-checkboxes li[data-task=U] > p > input:checked {
 .bases-cards-container {
   padding: 8px;
 	overflow: visible;
+}
+
+.bases-cards-container .bases-group-heading {
+  border-radius: 6px;
+  margin-bottom: 8px;
 }
 
 .bases-cards-item {

--- a/theme.css
+++ b/theme.css
@@ -29853,6 +29853,32 @@ body.enable-alternative-checkboxes li[data-task=U] > p > input:checked {
 
 /**** Bases start ****/
 
+/*=== Bases 基础设置 ===*/
+
+.bases-group-heading {
+	width: 100%;
+  font-weight: 600;
+  font-size: 0.9em;
+  color: var(--text-normal);
+  padding: 6px 0;
+  border-bottom: 1px solid var(--bases-table-border-color);
+	background: var(--bases-table-group-background);
+  margin-bottom: 8px;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.bases-group-property {
+  color: var(--text-muted);
+  font-size: 0.8em;
+  font-weight: 400;
+}
+
+.bases-group-value {
+  color: var(--text-accent);
+}
+
 /*=== Bases 表格视图 ===*/
 
 .bases-table-container {
@@ -29884,20 +29910,15 @@ body.enable-alternative-checkboxes li[data-task=U] > p > input:checked {
   background: var(--bases-table-cell-background-active);
 }
 
+.bases-table > .bases-group-heading:first-of-type {
+  margin-top: 8px;
+}
+
 /*=== Bases 卡片视图 ===*/
 
 .bases-cards-container {
   padding: 8px;
 	overflow: visible;
-}
-
-.bases-cards-container > .bases-group-heading:first-of-type {
-  margin-top: 8px;
-}
-
-.bases-cards-container .bases-group-heading {
-  border-radius: 6px;
-  margin-bottom: 8px;
 }
 
 .bases-cards-item {
@@ -29977,30 +29998,8 @@ body.enable-alternative-checkboxes li[data-task=U] > p > input:checked {
   white-space: normal;
 }
 
-.bases-group-heading {
-  font-weight: 600;
-  font-size: 0.9em;
-  color: var(--text-normal);
-  padding: 6px 0;
-  border-bottom: 1px solid var(--bases-table-border-color);
-  margin-bottom: 8px;
-  display: flex;
-  align-items: center;
-  gap: 6px;
-}
-
-.bases-table > .bases-group-heading:first-of-type {
+.bases-cards-container > .bases-group-heading:first-of-type {
   margin-top: 8px;
-}
-
-.bases-group-property {
-  color: var(--text-muted);
-  font-size: 0.8em;
-  font-weight: 400;
-}
-
-.bases-group-value {
-  color: var(--text-accent);
 }
 
 /*=== Bases 工具栏 ===*/
@@ -30044,15 +30043,6 @@ body.enable-alternative-checkboxes li[data-task=U] > p > input:checked {
 
 .bases-list-item .bases-list-property:first-child .bases-rendered-value:hover::after {
   content: "标题";
-}
-
-.bases-list-group > .bases-group-heading {
-  width: 100%;
-  height: var(--bases-table-row-height);
-  padding-inline-start: var(--size-4-2);
-  align-items: baseline;
-  line-height: var(--bases-table-row-height);
-  margin-bottom: 0;
 }
 
 /**** Bases end ****/

--- a/theme.css
+++ b/theme.css
@@ -29859,8 +29859,6 @@ body.enable-alternative-checkboxes li[data-task=U] > p > input:checked {
  	width: 100%;
   font-weight: 600;
   font-size: 1.1em;
-  text-align: center;
-  justify-content: center;
   color: var(--text-normal);
   padding: 6px 0;
   border-bottom: 1px solid var(--bases-table-border-color);
@@ -29924,6 +29922,8 @@ body.enable-alternative-checkboxes li[data-task=U] > p > input:checked {
 }
 
 .bases-cards-container .bases-group-heading {
+  justify-content: center;
+  text-align: center;
   border-radius: 6px;
   margin-bottom: 8px;
 }
@@ -30019,6 +30019,10 @@ body.enable-alternative-checkboxes li[data-task=U] > p > input:checked {
 }
 
 /*=== Bases 列表视图 ===*/
+
+.bases-list-group > .bases-group-heading {
+  margin-top: 8px;
+}
 
 .bases-list-item {
   font-size: 110%;

--- a/theme.css
+++ b/theme.css
@@ -30038,17 +30038,12 @@ body.enable-alternative-checkboxes li[data-task=U] > p > input:checked {
 }
 
 .bases-list-group > .bases-group-heading {
-  height: var(--bases-table-row-height, 32px);
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  font-weight: 600;
-  font-size: 0.9em;
-  color: var(--text-normal);
-  padding: 0 12px;
-  border-bottom: 1px solid var(--bases-table-border-color);
+  width: 100%;
+  height: var(--bases-table-row-height);
+  padding-inline-start: var(--size-4-2);
+  align-items: baseline;
+  line-height: var(--bases-table-row-height);
   margin-bottom: 0;
-  background: transparent;
 }
 
 /**** Bases end ****/


### PR DESCRIPTION
## 继续适配Bases插件

### 修改点： 适配Bases插件List视图
- 特性1：合适的间距
- 特性2：分组栏标题hover放大效果（同样在Table视图、Card视图增加）
- 特性3：数据行增加hover展示数据类型的效果
- 特性4：增加可供扩展的几个css属性，未来或许会开放style-setting自定义设置
- 特性5：【实验性】对Autumn配色增加分组栏背景色效果

<img width="1932" height="3271" alt="Blue Topaz Bases插件列表视图" src="https://github.com/user-attachments/assets/2fe4a5cf-aa74-48b1-910f-febb566bf62a" />

<img width="1920" height="1040" alt="分组栏hover效果" src="https://github.com/user-attachments/assets/c903eab3-189d-4779-8a67-39f49c07777a" />

