### PR TITLE
feat: support Notebook Navigator

### DIFF
--- a/theme.css
+++ b/theme.css
@@ -4788,6 +4788,20 @@ settings:
     type: class-toggle
     default: true
   -
+    id: style-options-for-notebook-navigator
+    title: 3.12 Notebook Navigator
+    title.zh: 3.12 适配Notebook Navigator
+    type: heading
+    level: 2
+    collapsed: true
+  -
+    id: notebook-navigator-support
+    title: Enable Notebook Navigator support
+    title.zh: 适配Notebook Navigator插件
+    description.zh: 使用 Blue Topaz 的语义色、边框和圆角适配 Notebook Navigator；关闭后恢复插件自身默认主题变量，不影响插件设置及用户自定义颜色。
+    type: class-toggle
+    default: true
+  -
     id: build-in-style-folder
     title: 4. Built-in style intro
     title.zh: 4. 内置样式介绍
@@ -30260,4 +30274,177 @@ body.bt-speech-bubble .markdown-source-view.mod-cm6 .cm-content > .HyperMD-task-
   [data-task="9"]
 ) {
   margin-block: var(--sb-gap) !important;
+}
+
+/* === Notebook Navigator ===
+   Uses the plugin's public --nn-theme-* API so every Blue Topaz palette and
+   both light/dark modes inherit the existing semantic theme tokens. */
+body.notebook-navigator-support {
+  /* Foreground */
+  --nn-theme-foreground: var(--text-normal);
+  --nn-theme-foreground-muted: var(--text-muted);
+  --nn-theme-foreground-faded: var(--text-faint);
+  --nn-theme-foreground-faint: color-mix(in srgb, var(--text-faint) 28%, transparent);
+
+  /* Surfaces, navigation and calendar */
+  --nn-theme-nav-bg: var(--background-secondary-alt);
+  --nn-theme-list-bg: var(--background-primary);
+  --nn-theme-mobile-bg: var(--background-mobile-drawer-1);
+  --nn-theme-nav-separator-color: var(--background-modifier-border);
+  --nn-theme-nav-separator-background: linear-gradient(90deg, transparent, var(--nn-theme-nav-separator-color) 18%, var(--nn-theme-nav-separator-color) 82%, transparent);
+  --nn-theme-nav-separator-height: 1px;
+  --nn-theme-nav-separator-opacity: 0.72;
+  --nn-theme-nav-indent-guide-color: var(--background-modifier-border);
+  --nn-theme-nav-leader-color: var(--text-faint);
+  --nn-theme-pinned-shortcut-shadow-color: color-mix(in srgb, var(--background-secondary-alt) 72%, transparent);
+  --nn-theme-calendar-header-color: var(--text-normal);
+  --nn-theme-calendar-weekday-color: var(--text-muted);
+  --nn-theme-calendar-week-color: var(--text-faint);
+  --nn-theme-calendar-day-in-month-color: var(--text-normal);
+  --nn-theme-calendar-day-outside-month-color: var(--text-faint);
+  --nn-theme-calendar-weekend-bg: color-mix(in srgb, var(--interactive-accent) 7%, transparent);
+  --nn-theme-calendar-hover-bg: var(--background-modifier-hover);
+  --nn-theme-calendar-note-indicator-color: var(--interactive-accent);
+  --nn-theme-calendar-unfinished-task-indicator-color: var(--text-error);
+  --nn-theme-calendar-feature-image-text-color: var(--text-on-accent);
+  --nn-theme-calendar-feature-image-overlay-color: rgb(0 0 0 / 0.08);
+  --nn-theme-calendar-day-today-color: var(--text-on-accent);
+  --nn-theme-calendar-day-today-bg: var(--interactive-accent);
+  --nn-theme-calendar-day-active-border-color: var(--interactive-accent);
+  --nn-theme-calendar-day-active-border-width: 2px;
+
+  /* Navigation rows */
+  --nn-theme-navitem-chevron-color: var(--text-muted);
+  --nn-theme-navitem-icon-color: var(--text-muted);
+  --nn-theme-navitem-name-color: var(--text-normal);
+  --nn-theme-navitem-file-name-color: var(--text-normal);
+  --nn-theme-navitem-count-color: var(--text-muted);
+  --nn-theme-navitem-count-bg: color-mix(in srgb, var(--background-primary-alt) 62%, transparent);
+  --nn-theme-navitem-count-border-radius: var(--radius-xs);
+  --nn-theme-navitem-border-radius: var(--radius-s);
+  --nn-theme-navitem-border-width: 1px;
+  --nn-theme-navitem-custom-border-color: transparent;
+  --nn-theme-navitem-hover-bg: color-mix(in srgb, var(--interactive-accent) 10%, transparent);
+  --nn-theme-navitem-hover-border-color: color-mix(in srgb, var(--interactive-accent) 18%, transparent);
+  --nn-theme-navitem-selected-bg: color-mix(in srgb, var(--interactive-accent) 18%, var(--background-secondary-alt));
+  --nn-theme-navitem-selected-border-color: color-mix(in srgb, var(--interactive-accent) 32%, transparent);
+  --nn-theme-navitem-selected-chevron-color: var(--text-normal);
+  --nn-theme-navitem-selected-icon-color: var(--interactive-accent);
+  --nn-theme-navitem-selected-name-color: var(--text-normal);
+  --nn-theme-navitem-selected-count-color: var(--text-normal);
+  --nn-theme-navitem-selected-count-bg: color-mix(in srgb, var(--interactive-accent) 20%, transparent);
+  --nn-theme-navitem-selected-inactive-bg: var(--background-modifier-hover);
+  --nn-theme-navitem-selected-inactive-border-color: var(--background-modifier-border);
+  --nn-theme-navitem-selected-inactive-chevron-color: var(--text-muted);
+  --nn-theme-navitem-selected-inactive-icon-color: var(--text-muted);
+  --nn-theme-navitem-selected-inactive-name-color: var(--text-normal);
+  --nn-theme-navitem-selected-inactive-count-color: var(--text-muted);
+  --nn-theme-navitem-selected-inactive-count-bg: var(--nn-theme-navitem-count-bg);
+  --nn-theme-navitem-count-border-width: 0;
+  --nn-theme-navitem-count-border-color: transparent;
+  --nn-theme-navitem-selected-count-border-color: transparent;
+  --nn-theme-navitem-selected-inactive-count-border-color: transparent;
+  --nn-theme-tag-positive-bg: color-mix(in srgb, var(--interactive-accent) 18%, transparent);
+  --nn-theme-tag-negative-bg: color-mix(in srgb, var(--text-error) 20%, transparent);
+  --nn-theme-navitem-name-font-weight: 400;
+  --nn-theme-navitem-file-name-font-weight: 400;
+  --nn-theme-navitem-count-font-weight: 400;
+  --nn-theme-navitem-custom-color-name-font-weight: 600;
+  --nn-theme-navitem-custom-color-file-name-font-weight: 600;
+  --nn-theme-navitem-folder-note-name-font-weight: 500;
+  --nn-theme-navitem-folder-note-name-decoration: underline dotted;
+  --nn-theme-navitem-folder-note-name-hover-decoration: underline;
+
+  /* Pane divider, list header and files */
+  --nn-theme-divider-border-color: var(--background-modifier-border);
+  --nn-theme-divider-resize-handle-hover-bg: var(--interactive-accent);
+  --nn-theme-list-header-icon-color: var(--text-muted);
+  --nn-theme-list-header-breadcrumb-color: var(--text-muted);
+  --nn-theme-list-header-breadcrumb-font-weight: 600;
+  --nn-theme-list-search-active-bg: color-mix(in srgb, var(--interactive-accent) 14%, transparent);
+  --nn-theme-list-search-border-color: var(--background-modifier-border);
+  --nn-theme-list-heading-color: var(--text-normal);
+  --nn-theme-list-heading-font-weight: 600;
+  --nn-theme-list-group-header-color: var(--text-muted);
+  --nn-theme-list-group-header-font-weight: 600;
+  --nn-theme-list-separator-color: var(--background-modifier-border);
+  --nn-theme-file-name-color: var(--text-normal);
+  --nn-theme-file-preview-color: var(--text-muted);
+  --nn-theme-file-task-icon-color: var(--interactive-accent);
+  --nn-theme-file-feature-border-radius: var(--radius-s);
+  --nn-theme-file-date-color: var(--text-faint);
+  --nn-theme-file-word-count-color: var(--text-faint);
+  --nn-theme-file-parent-color: var(--text-muted);
+  --nn-theme-file-tag-color: var(--text-muted);
+  --nn-theme-file-tag-bg: color-mix(in srgb, var(--interactive-accent) 7%, transparent);
+  --nn-theme-file-tag-border-color: color-mix(in srgb, var(--interactive-accent) 22%, transparent);
+  --nn-theme-file-tag-border-radius: var(--radius-s);
+  --nn-theme-file-tag-custom-color-text-color: var(--text-on-accent);
+  --nn-theme-file-property-color: var(--text-muted);
+  --nn-theme-file-property-bg: color-mix(in srgb, var(--background-primary-alt) 70%, transparent);
+  --nn-theme-file-property-border-color: var(--background-modifier-border);
+  --nn-theme-file-property-border-radius: var(--radius-s);
+  --nn-theme-file-border-radius: var(--radius-m);
+  --nn-theme-file-border-width: 1px;
+  --nn-theme-file-pill-border-width: 1px;
+  --nn-theme-file-selected-bg: color-mix(in srgb, var(--interactive-accent) 16%, var(--background-primary));
+  --nn-theme-file-selected-border-color: color-mix(in srgb, var(--interactive-accent) 30%, transparent);
+  --nn-theme-file-selected-name-color: var(--text-normal);
+  --nn-theme-file-selected-preview-color: var(--text-muted);
+  --nn-theme-file-selected-date-color: var(--text-muted);
+  --nn-theme-file-selected-word-count-color: var(--text-muted);
+  --nn-theme-file-selected-parent-color: var(--text-normal);
+  --nn-theme-file-selected-tag-color: var(--text-normal);
+  --nn-theme-file-selected-tag-bg: color-mix(in srgb, var(--interactive-accent) 16%, transparent);
+  --nn-theme-file-selected-tag-border-color: color-mix(in srgb, var(--interactive-accent) 32%, transparent);
+  --nn-theme-file-selected-property-color: var(--text-normal);
+  --nn-theme-file-selected-property-bg: color-mix(in srgb, var(--interactive-accent) 12%, transparent);
+  --nn-theme-file-selected-property-border-color: color-mix(in srgb, var(--interactive-accent) 28%, transparent);
+  --nn-theme-file-selected-inactive-bg: var(--background-modifier-hover);
+  --nn-theme-file-selected-inactive-border-color: var(--background-modifier-border);
+  --nn-theme-file-selected-inactive-name-color: var(--text-normal);
+  --nn-theme-file-selected-inactive-preview-color: var(--text-muted);
+  --nn-theme-file-selected-inactive-date-color: var(--text-faint);
+  --nn-theme-file-selected-inactive-word-count-color: var(--text-faint);
+  --nn-theme-file-selected-inactive-parent-color: var(--text-muted);
+  --nn-theme-file-selected-inactive-tag-color: var(--text-muted);
+  --nn-theme-file-selected-inactive-tag-bg: var(--nn-theme-file-tag-bg);
+  --nn-theme-file-selected-inactive-property-color: var(--text-muted);
+  --nn-theme-file-selected-inactive-property-bg: var(--nn-theme-file-property-bg);
+  --nn-theme-file-name-font-weight: 600;
+  --nn-theme-file-compact-name-font-weight: 400;
+  --nn-theme-file-preview-font-weight: 400;
+  --nn-theme-file-date-font-weight: 400;
+  --nn-theme-file-word-count-font-weight: 400;
+  --nn-theme-file-parent-font-weight: 400;
+  --nn-theme-file-tag-font-weight: 400;
+
+  /* Header actions and quick actions */
+  --nn-theme-header-button-icon-color: var(--text-muted);
+  --nn-theme-header-button-hover-bg: var(--background-modifier-hover);
+  --nn-theme-header-button-active-bg: color-mix(in srgb, var(--interactive-accent) 16%, transparent);
+  --nn-theme-header-button-active-icon-color: var(--interactive-accent);
+  --nn-theme-header-button-disabled-icon-color: var(--text-faint);
+  --nn-theme-quick-actions-bg: color-mix(in srgb, var(--background-primary) 94%, transparent);
+  --nn-theme-quick-actions-border: var(--background-modifier-border);
+  --nn-theme-quick-actions-border-radius: var(--radius-s);
+  --nn-theme-quick-actions-icon-color: var(--text-muted);
+  --nn-theme-quick-actions-icon-hover-color: var(--interactive-accent);
+  --nn-theme-quick-actions-separator-color: var(--background-modifier-border);
+
+  /* Mobile */
+  --nn-theme-mobile-list-header-link-color: var(--text-accent);
+  --nn-theme-mobile-list-header-breadcrumb-color: var(--text-normal);
+  --nn-theme-mobile-list-header-breadcrumb-font-weight: 600;
+  --nn-theme-mobile-toolbar-bg: var(--background-secondary-alt);
+  --nn-theme-mobile-toolbar-button-icon-color: var(--text-muted);
+  --nn-theme-mobile-toolbar-button-active-bg: color-mix(in srgb, var(--interactive-accent) 16%, transparent);
+  --nn-theme-mobile-toolbar-button-active-icon-color: var(--interactive-accent);
+  --nn-theme-mobile-toolbar-glass-bg: var(--background-primary);
+}
+
+body.notebook-navigator-support.theme-dark {
+  --nn-theme-pinned-shortcut-shadow-color: rgb(0 0 0 / 0.22);
+  --nn-theme-calendar-feature-image-overlay-color: rgb(0 0 0 / 0.32);
+  --nn-theme-file-tag-custom-color-text-color: var(--text-on-accent);
 }


### PR DESCRIPTION
## 修改概述

- 为 Notebook Navigator 增加 Blue Topaz 主题适配。
- 在 Style Settings 中提供默认开启的适配总开关。

## 修改内容

- 使用插件公开的 `--nn-theme-*` 变量映射主题文字、背景、交互态、边框、圆角、日历、工具栏及移动端样式。
- 保留插件单双栏、响应式布局与用户自定义颜色的优先级。
- 新增“3.12 适配Notebook Navigator”，关闭后恢复插件默认外观。

## 适配说明

| 适配点                   | 主题侧处理                                              | 预期效果                                                          |
| --------------------- | -------------------------------------------------- | ------------------------------------------------------------- |
| 导航／文件／移动端表面           | 分别映射 `nav-bg`、`list-bg`、`mobile-bg` 到主题语义背景        | 左栏双面有层次，移动端不沿用桌面分栏底色                                          |
| 文字与辅助信息               | 正文、muted、faded、faint 统一使用现有文字令牌                    | 标题、路径、计数、预览信息在所有配色下保持信息层级                                     |
| 导航树与当前项               | 映射图标、名称、计数、hover、激活／失焦选中态及边框                       | 树形导航不丢失选中反馈；失焦时不过度抢眼                                          |
| 双栏分隔                  | 映射分隔线和拖拽手柄 hover 色，不设任何宽高规则                        | 横向与竖向分隔均沿用 Blue Topaz 的边框和强调色                                 |
| 文件卡片与元数据              | 映射标题、预览、日期、父路径、标签、属性 pill、缩略图圆角与选中态                | 富文件列表仍有卡片层级，标签／属性不会显得像插件默认样式                                  |
| 日历、工具栏与快速操作           | 映射日历文本／今天／活动态、header 按钮和 quick action 表面           | 非列表组件也跟随主题深浅色和强调色                                             |
| 自定义颜色与 Style Settings | 不用插件内部 class 覆盖用户颜色；只提供默认变量                        | 文件、文件夹、标签、属性的插件自定义色仍优先；Style Settings 可继续改写多数变量               |
| 主题总开关                 | 以 `body.notebook-navigator-support` 包住全部 150 个映射变量 | 在 Style Settings 的 `3.12 适配Notebook Navigator` 中可一键启用／关闭；默认开启 |
| 深色模式差异                | 只为暗色补充阴影和 feature-image 遮罩的透明度                     | 阴影、图片上的文字在深色背景中仍有可读性                                          |

## 适配思路

### 1. 以插件公开变量为边界

Notebook Navigator 的官方 Theming Guide 明确将 `--nn-theme-*` 作为主题扩展 API，并说明变量可定义在 `body`、`.theme-light` 或 `.theme-dark`。主题在 `theme.css` 末尾声明全部 **150/150** 个公开变量，而不是依赖插件内部 DOM class。

这样做的结果是：插件负责组件结构、虚拟列表、分栏动画与可拖拽尺寸；主题负责颜色、边框、圆角和字重。插件升级时，主题不需要猜测其 React 组件或内部 class 是否仍然存在。

### 2. 用语义令牌，而非固定颜色或尺寸

背景使用 `background-primary`、`background-secondary-alt`、`background-mobile-drawer-1`；交互态使用 `interactive-accent`；文字、边框和圆角也均取自已有 Blue Topaz 令牌。故 12 个配色和深浅色切换会自然传递到 Navigator，不新增硬编码的配色分支。

主题也**不设置**导航栏宽度、面板最小宽高、分栏方向、断点或 pane transform。官方实现本身拥有横向／竖向最小尺寸及单栏过渡；主题若写死这些布局值，会破坏用户调整宽度后的自动降级行为。

### 3. 尊重插件配置的优先级

官方文档说明：桌面背景模式 `Separate` 使用两种 pane 背景，`Primary` 会让导航采用文件列表背景，`Secondary` 会让列表采用导航背景。主题只提供这两种背景变量，因此三种模式的交换仍由插件完成。

文件、文件夹、标签与属性的自定义颜色由插件的行级变量／inline style 给出，优先于主题默认值；主题没有针对这些元素增加选择器覆盖。Style Settings 暴露的大多数 `--nn-theme-*` 同样可以继续作为用户级覆盖入口。

## 效果图

- 浅色配色，双栏-水平分隔示例：
<img width="7680" height="3240" alt="notebook-navigator-color-matrix-light" src="https://github.com/user-attachments/assets/8897f8a5-9440-4ee1-8464-2245358cbe49" />


- 深色配色，双栏-垂直分隔示例：
<img width="7680" height="3240" alt="notebook-navigator-color-matrix-dark" src="https://github.com/user-attachments/assets/3aefc5d8-8371-44bf-b6a4-deb4a9290b98" />


