### PR TITLE
Fix --canvas-color for Obsidian 1.13+

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
     "name": "Blue Topaz",
     "version": "2026072001",
-    "minAppVersion": "1.0.0",
+    "minAppVersion": "1.13.0",
     "author": "WhyI & Pkmer",
     "authorUrl": "https://github.com/PKM-er"
 }

--- a/theme.css
+++ b/theme.css
@@ -29094,7 +29094,7 @@ body.canvas-card-focus-mode .canvas:has(.is-focused.mod-canvas-color-custom) .ca
 }
 
 .canvas-node-placeholder::after {
-  background-color: rgba(var(--canvas-color), 0.3);
+  background-color: color-mix(in srgb, var(--canvas-color) 30%, transparent);
 }
 .canvas-icon-placeholder svg {
   opacity: 0.5;


### PR DESCRIPTION
Hello! I'm [saberzero1](https://github.com/saberzero1), a [community reviewer](https://obsidian.md/help/credits#Community+review) for Obsidian plugins and themes. We're sending this PR out to you proactively to help you prepare for a recent Obsidian update.

## Summary

Obsidian 1.13 changed how `--canvas-color` (and `--canvas-color-1` through `--canvas-color-6`) works. It now provides a valid CSS color value (e.g. `#e93147`) instead of a bare RGB triplet (`233, 49, 71`).

This breaks two patterns:

**1. Bare RGB triplets in declarations:**
```css
/* Before (broken on 1.13+) */
--canvas-color-1: 255, 0, 128;
/* After */
--canvas-color-1: rgb(255, 0, 128);
```

**2. Wrapping `var(--canvas-color)` in `rgb()`/`rgba()`:**
```css
/* Before (produces invalid rgb(rgb(...)) on 1.13+) */
background: rgba(var(--canvas-color), 0.1);
/* After */
background: color-mix(in srgb, var(--canvas-color) 10%, transparent);
```

## Changes

- Wrapped bare RGB triplets in `--canvas-color` / `--canvas-color-N` declarations with `rgb()`
- Replaced `rgb(var(--canvas-color))` with `var(--canvas-color)`
- Replaced `rgba(var(--canvas-color), <alpha>)` with `color-mix(in srgb, var(--canvas-color) <percent>, transparent)`
- Updated `minAppVersion` in `manifest.json` to `1.13.0` (if it was lower)

## Context

See the [Obsidian 1.13 changelog](https://obsidian.md/changelog/) for details on this breaking change.
